### PR TITLE
docs: add invalid_exact_svm_payload_transaction_instructions_length error code

### DIFF
--- a/x402/reference.mdx
+++ b/x402/reference.mdx
@@ -602,6 +602,7 @@ The x402 protocol defines standard error codes that may be returned by facilitat
 - **`invalid_exact_evm_payload_authorization_value`**: Payment amount is insufficient for the required payment
 - **`invalid_exact_evm_payload_signature`**: Payment authorization signature is invalid or improperly signed
 - **`invalid_exact_evm_payload_recipient_mismatch`**: Recipient address does not match payment requirements
+- **`invalid_exact_svm_payload_transaction_instructions_length`**: Solana transaction must contain exactly 3 instructions: `setComputeUnitLimit`, `setComputeUnitPrice`, and `createTransferCheckedInstruction`
 - **`invalid_network`**: Specified blockchain network is not supported
 - **`invalid_payload`**: Payment payload is malformed or contains invalid data
 - **`invalid_payment_requirements`**: Payment requirements object is invalid or malformed


### PR DESCRIPTION
Add documentation for the `invalid_exact_svm_payload_transaction_instructions_length` error code to the `x402` reference documentation. This error occurs when Solana transactions don't include the required 3 instructions for the "exact" payment scheme:
`setComputeUnitLimit`
`setComputeUnitPrice`
`createTransferCheckedInstruction`
Changes
Added new error code entry in the Error Handling section of [x402/reference.mdx]