### PR TITLE
docs: add SKALE Base networks

### DIFF
--- a/snippets/supported-networks-table.mdx
+++ b/snippets/supported-networks-table.mdx
@@ -4,6 +4,8 @@
 | Avalanche Fuji   | `avalanche-fuji`|
 | Base             | `base`          |
 | Base Sepolia     | `base-sepolia`  |
+| SKALE Base       | `skale-base`    |
+| SKALE Base Spolia| `skale-base-spolia` |
 | IoTeX            | `iotex`         |
 | Peaq             | `peaq`          |
 | Polygon          | `polygon`       |

--- a/x402-echo/getting-started.mdx
+++ b/x402-echo/getting-started.mdx
@@ -31,6 +31,8 @@ https://x402.payai.network/api/solana-devnet/paid-content
 https://x402.payai.network/api/solana-mainnet/paid-content
 https://x402.payai.network/api/base/paid-content
 https://x402.payai.network/api/base-sepolia/paid-content
+https://x402.payai.network/api/skale-base/paid-content
+https://x402.payai.network/api/skale-base-spolia/paid-content
 ```
 
 ## Step 3 — Run and observe

--- a/x402/reference.mdx
+++ b/x402/reference.mdx
@@ -472,6 +472,16 @@ Returns the list of payment schemes and networks supported by the facilitator.
     {
       "x402Version": 1,
       "scheme": "exact",
+      "network": "skale-base-spolia"
+    },
+    {
+      "x402Version": 1,
+      "scheme": "exact",
+      "network": "skale-base"
+    },
+    {
+      "x402Version": 1,
+      "scheme": "exact",
       "network": "avalanche-fuji"
     },
     {
@@ -636,6 +646,8 @@ The following blockchain networks are currently supported by the reference imple
 
 - **`base-sepolia`**: Base Sepolia testnet (Chain ID: 84532)
 - **`base`**: Base mainnet (Chain ID: 8453)
+- **`skale-base-spolia`**: SKALE Base Spolia (Chain ID: 324705682)
+- **`skale-base`**: SKALE Base (Chain ID: 1187947933)
 - **`avalanche-fuji`**: Avalanche Fuji testnet (Chain ID: 43113)
 - **`avalanche`**: Avalanche mainnet (Chain ID: 43114)
 


### PR DESCRIPTION
Adds skale-base and skale-base-spolia to supported networks docs (table + reference + echo getting-started examples).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation to include SKALE Base networks.
> 
> - Add `skale-base` and `skale-base-spolia` to `snippets/supported-networks-table.mdx`
> - Extend Echo examples in `x402-echo/getting-started.mdx` with `.../api/skale-base/paid-content` and `.../api/skale-base-spolia/paid-content`
> - Update `x402/reference.mdx`:
>   - Include both networks in `GET /supported` `kinds` list
>   - Add both networks to Supported Networks (with chain IDs)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b86803cfd74f5b96e547546e6c98bc0f710c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->