### PR TITLE
feat: add Google Tag Manager integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -250,6 +250,11 @@
       "linkedin": "https://linkedin.com/company/PayAINetwork"
     }
   },
+  "integrations": {
+    "gtm": {
+      "tagId": "GTM-N5V93RM6"
+    }
+  },
   "banner": {
       "content": "🎉 x402 is now live on Solana!"
   }


### PR DESCRIPTION
## Summary
- Adds GTM container (`GTM-N5V93RM6`) to Mintlify docs via the `integrations.gtm` config in `docs.json`

## Test plan
- [ ] Verify docs deploy successfully
- [ ] Confirm GTM script loads on the published site (check page source or GTM debugger)