### PR TITLE
docs: update x402 repo refs from coinbase to x402-foundation

### DIFF
--- a/guides/dynamic-pricing-x402.mdx
+++ b/guides/dynamic-pricing-x402.mdx
@@ -108,7 +108,7 @@ export const GET = withX402(
 );
 ```
 
-Your `proxy.ts` (or shared server setup) should export `server`, `paywall`, and `evmAddress` / `svmAddress` as in the [Next.js x402 example](https://github.com/coinbase/x402/tree/main/examples/typescript/fullstack/next).
+Your `proxy.ts` (or shared server setup) should export `server`, `paywall`, and `evmAddress` / `svmAddress` as in the [Next.js x402 example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next).
 
 ---
 
@@ -463,7 +463,7 @@ Register separate route patterns per tier, e.g. `GET /api/insight/basic`, `GET /
 **Option B – One route, dynamic price by hand**  
 Use a single route that does **not** go through the middleware's static route table for payment. In the handler, read `tier` from the request, compute the price, build payment requirements (and optionally call the facilitator's verify/settle), and return 402 or proceed. That means you implement the 402 flow yourself for that route while still using the same facilitator and schemes elsewhere.
 
-Example sketch for **Option B** with Gin: in a handler, get the tier from query or header, map it to a price string, build a `RouteConfig`-like struct for that request, then use the Go HTTP server's low-level APIs (if exposed) to run verify/settle with that config. The [Gin example](https://github.com/coinbase/x402/tree/main/examples/go/servers/gin) uses static `RoutesConfig`; for true per-request price you'd call the resource server's verify/settle with requirements you build from the current request's tier.
+Example sketch for **Option B** with Gin: in a handler, get the tier from query or header, map it to a price string, build a `RouteConfig`-like struct for that request, then use the Go HTTP server's low-level APIs (if exposed) to run verify/settle with that config. The [Gin example](https://github.com/x402-foundation/x402/tree/main/examples/go/servers/gin) uses static `RoutesConfig`; for true per-request price you'd call the resource server's verify/settle with requirements you build from the current request's tier.
 
 ---
 
@@ -494,4 +494,4 @@ For more on x402, see the [x402 introduction](/x402/introduction), [x402 referen
 
 ### Still looking for more?
 
-Check out the [Coinbase x402 repository](https://github.com/coinbase/x402) for the official protocol spec, SDK source, and additional examples.
+Check out the [x402 repository](https://github.com/x402-foundation/x402) for the official protocol spec, SDK source, and additional examples.

--- a/v1/x402/clients/python/httpx.mdx
+++ b/v1/x402/clients/python/httpx.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with an httpx client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/clients/httpx).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx).</Note>
 
 ### Step 1: Install dependencies
 
@@ -121,7 +121,7 @@ python main.py
 
 ### Step 5: Test the client
 
-You can test payments against a local server by running the [fastapi example](https://github.com/coinbase/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/coinbase/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
+You can test payments against a local server by running the [fastapi example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/v1/x402/clients/python/requests.mdx
+++ b/v1/x402/clients/python/requests.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with a requests client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/clients/requests).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests).</Note>
 
 ### Step 1: Install dependencies
 
@@ -119,7 +119,7 @@ python main.py
 
 ### Step 5: Test the client
 
-You can test payments against a local server by running the [fastapi example](https://github.com/coinbase/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/coinbase/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
+You can test payments against a local server by running the [fastapi example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/v1/x402/clients/typescript/axios.mdx
+++ b/v1/x402/clients/typescript/axios.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with an Axios client in 2 minutes.
 
-<Note>You can find the full code for this example <a href="https://github.com/coinbase/x402/tree/main/examples/typescript/clients/axios" target="_blank">here</a>.</Note>
+<Note>You can find the full code for this example <a href="https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios" target="_blank">here</a>.</Note>
 
 ### Step 1: Create a new client from the starter template
 

--- a/v1/x402/clients/typescript/fetch.mdx
+++ b/v1/x402/clients/typescript/fetch.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with a Fetch client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/0dfd3e683f1563543bd62a3ad84cbc6851d4054b/examples/typescript/clients/fetch).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/0dfd3e683f1563543bd62a3ad84cbc6851d4054b/examples/typescript/clients/fetch).</Note>
 
 ### Step 1: Create a new client from the starter template
 

--- a/v1/x402/reference.mdx
+++ b/v1/x402/reference.mdx
@@ -7,13 +7,13 @@ import SupportedNetworksTable from "/snippets/supported-networks-table.mdx";
 import FacilitatorsTable from "/snippets/facilitators-table.mdx";
 import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
-<Note>Once merged, you will be able to read the x402 protocol specification in the [x402 repository](https://github.com/coinbase/x402/specs/x402-specification.md).</Note>
+<Note>Once merged, you will be able to read the x402 protocol specification in the [x402 repository](https://github.com/x402-foundation/x402/specs/x402-specification.md).</Note>
 
 ## 1. Overview
 
 x402 is an open payment standard that enables clients to pay for HTTP resources using blockchain technology. The protocol leverages the existing HTTP 402 "Payment Required" status code to indicate when payment is required for resource access, providing a standardized mechanism for micropayments on the web. 
 
-This specification is based on the x402 protocol implementation and documentation available in the [Coinbase x402 repository](https://github.com/coinbase/x402). It aims to provide a comprehensive and implementation-agnostic specification for the x402 HTTP-native micropayment protocol.
+This specification is based on the x402 protocol implementation and documentation available in the [x402 repository](https://github.com/x402-foundation/x402). It aims to provide a comprehensive and implementation-agnostic specification for the x402 HTTP-native micropayment protocol.
 
 ## 2. Core Payment Flow
 

--- a/v1/x402/servers/python/fastapi.mdx
+++ b/v1/x402/servers/python/fastapi.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your FastAPI server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/servers/fastapi).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/fastapi).</Note>
 
 ### Step 1: Install dependencies
 
@@ -118,7 +118,7 @@ uvicorn main:app --reload
 
 ### Step 5: Test the server
 
-You can test payments against your server locally by following the [httpx example](https://github.com/coinbase/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/coinbase/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
+You can test payments against your server locally by following the [httpx example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/v1/x402/servers/python/flask.mdx
+++ b/v1/x402/servers/python/flask.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Flask server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/servers/flask).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/flask).</Note>
 
 ### Step 1: Install dependencies
 
@@ -113,7 +113,7 @@ flask run
 
 ### Step 5: Test the server
 
-You can test payments against your server locally by following the [httpx example](https://github.com/coinbase/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/coinbase/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
+You can test payments against your server locally by following the [httpx example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/v1/x402/servers/typescript/express.mdx
+++ b/v1/x402/servers/typescript/express.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Express server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/express).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express).</Note>
 
 ### Step 1: Create a new server from the starter template
 

--- a/v1/x402/servers/typescript/hono.mdx
+++ b/v1/x402/servers/typescript/hono.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting 402 payments in your Hono server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/hono).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/hono).</Note>
 
 ### Step 1: Install dependencies
 

--- a/x402/clients/go/http.mdx
+++ b/x402/clients/go/http.mdx
@@ -4,16 +4,16 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with Go's standard `net/http` client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/go/clients/http).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/go/clients/http).</Note>
 
 ### Step 1: Create a Go module and install dependencies
 
 ```bash
 go mod init myclient
-go get github.com/coinbase/x402/go github.com/joho/godotenv
+go get github.com/x402-foundation/x402/go github.com/joho/godotenv
 ```
 
-To run from the x402 repo instead: clone [coinbase/x402](https://github.com/coinbase/x402), then `cd examples/go/clients/http`, copy `.env-example` to `.env`, and run `go run . mechanism-helper-registration` (or `go run . builder-pattern`).
+To run from the x402 repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then `cd examples/go/clients/http`, copy `.env-example` to `.env`, and run `go run . mechanism-helper-registration` (or `go run . builder-pattern`).
 
 ### Step 2: Set your environment variables
 
@@ -48,12 +48,12 @@ import (
 	"os"
 	"time"
 
-	x402 "github.com/coinbase/x402/go"
-	x402http "github.com/coinbase/x402/go/http"
-	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/client"
-	svm "github.com/coinbase/x402/go/mechanisms/svm/exact/client"
-	evmsigners "github.com/coinbase/x402/go/signers/evm"
-	svmsigners "github.com/coinbase/x402/go/signers/svm"
+	x402 "github.com/x402-foundation/x402/go"
+	x402http "github.com/x402-foundation/x402/go/http"
+	evm "github.com/x402-foundation/x402/go/mechanisms/evm/exact/client"
+	svm "github.com/x402-foundation/x402/go/mechanisms/svm/exact/client"
+	evmsigners "github.com/x402-foundation/x402/go/signers/evm"
+	svmsigners "github.com/x402-foundation/x402/go/signers/svm"
 	"github.com/joho/godotenv"
 )
 
@@ -132,7 +132,7 @@ func main() {
 }
 ```
 
-For a full runnable example with payment-response decoding and both builder-pattern and mechanism-helper registration, see the [upstream Go HTTP client](https://github.com/coinbase/x402/tree/main/examples/go/clients/http) (`main.go`, `utils.go`, `mechanism_helper_registration.go`, `builder_pattern.go`).
+For a full runnable example with payment-response decoding and both builder-pattern and mechanism-helper registration, see the [upstream Go HTTP client](https://github.com/x402-foundation/x402/tree/main/examples/go/clients/http) (`main.go`, `utils.go`, `mechanism_helper_registration.go`, `builder_pattern.go`).
 
 ### Step 4: Run the client
 

--- a/x402/clients/python/httpx.mdx
+++ b/x402/clients/python/httpx.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with an httpx client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/clients/httpx).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx).</Note>
 
 ### Step 1: Install dependencies
 
@@ -12,7 +12,7 @@ Make x402 payments with an httpx client in 2 minutes.
 pip install x402 httpx eth-account python-dotenv
 ```
 
-To run from the x402 repo instead: clone [coinbase/x402](https://github.com/coinbase/x402), then from the python examples root run the setup steps in the [httpx README](https://github.com/coinbase/x402/tree/main/examples/python/clients/httpx), copy `.env-local` to `.env`, and run the example.
+To run from the x402 repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the python examples root run the setup steps in the [httpx README](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx), copy `.env-local` to `.env`, and run the example.
 
 ### Step 2: Set your environment variables
 
@@ -154,7 +154,7 @@ python main.py
 
 ### Step 5: Test the client
 
-You can test payments against a local server by running the [fastapi example](https://github.com/coinbase/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/coinbase/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
+You can test payments against a local server by running the [fastapi example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/x402/clients/python/requests.mdx
+++ b/x402/clients/python/requests.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with a requests client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/clients/requests).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests).</Note>
 
 ### Step 1: Install dependencies
 
@@ -12,7 +12,7 @@ Make x402 payments with a requests client in 2 minutes.
 pip install x402 requests eth-account python-dotenv
 ```
 
-To run from the x402 repo instead: clone [coinbase/x402](https://github.com/coinbase/x402), then from the python examples root follow the [requests example](https://github.com/coinbase/x402/tree/main/examples/python/clients/requests), copy `.env-local` to `.env`, and run the example.
+To run from the x402 repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the python examples root follow the [requests example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests), copy `.env-local` to `.env`, and run the example.
 
 ### Step 2: Set your environment variables
 
@@ -152,7 +152,7 @@ python main.py
 
 ### Step 5: Test the client
 
-You can test payments against a local server by running the [fastapi example](https://github.com/coinbase/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/coinbase/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
+You can test payments against a local server by running the [fastapi example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/fastapi) or the [flask example](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/flask) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/x402/clients/typescript/axios.mdx
+++ b/x402/clients/typescript/axios.mdx
@@ -4,11 +4,11 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with an Axios client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/typescript/clients/axios).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios).</Note>
 
 ### Step 1: Create a new client
 
-Use the starter or run the [upstream example](https://github.com/coinbase/x402/tree/main/examples/typescript/clients/axios) from the x402 repo.
+Use the starter or run the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios) from the x402 repo.
 
 ##### npm (npx)
 ```bash
@@ -25,7 +25,7 @@ pnpm dlx @payai/x402-axios-starter@latest my-first-client
 bunx @payai/x402-axios-starter@latest my-first-client
 ```
 
-The starter mirrors the upstream example and bootstraps a ready-to-run Axios client. To run from the repo instead: clone [coinbase/x402](https://github.com/coinbase/x402), then from the typescript examples root run `pnpm install && pnpm build`, then `cd clients/axios`, copy `.env-local` to `.env`, and run `pnpm dev`.
+The starter mirrors the upstream example and bootstraps a ready-to-run Axios client. To run from the repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the typescript examples root run `pnpm install && pnpm build`, then `cd clients/axios`, copy `.env-local` to `.env`, and run `pnpm dev`.
 
 ### Step 2: Set your environment variables
 

--- a/x402/clients/typescript/fetch.mdx
+++ b/x402/clients/typescript/fetch.mdx
@@ -4,11 +4,11 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Make x402 payments with a Fetch client in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/typescript/clients/fetch).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/fetch).</Note>
 
 ### Step 1: Create a new client
 
-Use the starter or run the [upstream example](https://github.com/coinbase/x402/tree/main/examples/typescript/clients/fetch) from the x402 repo.
+Use the starter or run the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/fetch) from the x402 repo.
 
 ##### npm (npx)
 ```bash
@@ -25,7 +25,7 @@ pnpm dlx @payai/x402-fetch-starter@latest my-first-client
 bunx @payai/x402-fetch-starter@latest my-first-client
 ```
 
-The starter mirrors the upstream example and bootstraps a ready-to-run Fetch client. To run from the repo instead: clone [coinbase/x402](https://github.com/coinbase/x402), then from the typescript examples root run `pnpm install && pnpm build`, then `cd clients/fetch`, copy `.env-local` to `.env`, and run `pnpm dev`.
+The starter mirrors the upstream example and bootstraps a ready-to-run Fetch client. To run from the repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the typescript examples root run `pnpm install && pnpm build`, then `cd clients/fetch`, copy `.env-local` to `.env`, and run `pnpm dev`.
 
 ### Step 2: Set your environment variables
 

--- a/x402/reference.mdx
+++ b/x402/reference.mdx
@@ -7,13 +7,13 @@ import SupportedNetworksTable from "/snippets/supported-networks-table.mdx";
 import FacilitatorsTable from "/snippets/facilitators-table.mdx";
 import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
-<Note>Once merged, you will be able to read the x402 protocol specification in the [x402 repository](https://github.com/coinbase/x402/specs/x402-specification.md).</Note>
+<Note>Once merged, you will be able to read the x402 protocol specification in the [x402 repository](https://github.com/x402-foundation/x402/specs/x402-specification.md).</Note>
 
 ## 1. Overview
 
 x402 is an open payment standard that enables clients to pay for HTTP resources using blockchain technology. The protocol leverages the existing HTTP 402 "Payment Required" status code to indicate when payment is required for resource access, providing a standardized mechanism for micropayments on the web. 
 
-This specification is based on the x402 protocol implementation and documentation available in the [Coinbase x402 repository](https://github.com/coinbase/x402). It aims to provide a comprehensive and implementation-agnostic specification for the x402 HTTP-native micropayment protocol.
+This specification is based on the x402 protocol implementation and documentation available in the [x402 repository](https://github.com/x402-foundation/x402). It aims to provide a comprehensive and implementation-agnostic specification for the x402 HTTP-native micropayment protocol.
 
 ## 2. Core Payment Flow
 

--- a/x402/servers/go/gin.mdx
+++ b/x402/servers/go/gin.mdx
@@ -11,6 +11,7 @@ Start accepting x402 payments in your Gin server in 2 minutes.
 ```bash
 go mod init myserver
 go get github.com/x402-foundation/x402/go github.com/gin-gonic/gin github.com/joho/godotenv
+go mod tidy
 ```
 
 ### Step 2: Set your environment variables

--- a/x402/servers/go/gin.mdx
+++ b/x402/servers/go/gin.mdx
@@ -4,13 +4,13 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Gin server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/go/servers/gin).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/go/servers/gin).</Note>
 
 ### Step 1: Create a Go module and install dependencies
 
 ```bash
 go mod init myserver
-go get github.com/coinbase/x402/go github.com/gin-gonic/gin github.com/joho/godotenv
+go get github.com/x402-foundation/x402/go github.com/gin-gonic/gin github.com/joho/godotenv
 ```
 
 ### Step 2: Set your environment variables
@@ -36,11 +36,11 @@ import (
 	"os"
 	"time"
 
-	x402 "github.com/coinbase/x402/go"
-	x402http "github.com/coinbase/x402/go/http"
-	ginmw "github.com/coinbase/x402/go/http/gin"
-	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/server"
-	svm "github.com/coinbase/x402/go/mechanisms/svm/exact/server"
+	x402 "github.com/x402-foundation/x402/go"
+	x402http "github.com/x402-foundation/x402/go/http"
+	ginmw "github.com/x402-foundation/x402/go/http/gin"
+	evm "github.com/x402-foundation/x402/go/mechanisms/evm/exact/server"
+	svm "github.com/x402-foundation/x402/go/mechanisms/svm/exact/server"
 	ginfw "github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 )
@@ -191,7 +191,7 @@ go run .
 
 ### Step 5: Test the server
 
-You can test payments against your server locally by following the [fetch example](/x402/clients/typescript/fetch) or the [axios example](/x402/clients/typescript/axios), or by using the Go client examples in the [x402 repository](https://github.com/coinbase/x402/tree/main/examples/go/clients).
+You can test payments against your server locally by following the [fetch example](/x402/clients/typescript/fetch) or the [axios example](/x402/clients/typescript/axios), or by using the Go client examples in the [x402 repository](https://github.com/x402-foundation/x402/tree/main/examples/go/clients).
 
 ## x402 reference
 

--- a/x402/servers/python/fastapi.mdx
+++ b/x402/servers/python/fastapi.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your FastAPI server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/servers/fastapi).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/fastapi).</Note>
 
 ### Step 1: Install dependencies
 
@@ -155,7 +155,7 @@ uvicorn main:app --reload
 
 ### Step 5: Test the server
 
-You can test payments against your server locally by following the [httpx example](https://github.com/coinbase/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/coinbase/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
+You can test payments against your server locally by following the [httpx example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/x402/servers/python/flask.mdx
+++ b/x402/servers/python/flask.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Flask server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/python/servers/flask).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/flask).</Note>
 
 ### Step 1: Install dependencies
 
@@ -138,7 +138,7 @@ flask run
 
 ### Step 5: Test the server
 
-You can test payments against your server locally by following the [httpx example](https://github.com/coinbase/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/coinbase/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
+You can test payments against your server locally by following the [httpx example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx) or the [requests example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests) from the x402 repository.  
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 

--- a/x402/servers/typescript/express.mdx
+++ b/x402/servers/typescript/express.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Express server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/express).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express).</Note>
 
 ### Step 1: Create a new server from the starter template
 
@@ -25,7 +25,7 @@ pnpm dlx @payai/x402-express-starter@latest my-server
 bunx @payai/x402-express-starter@latest my-server
 ```
 
-The starter mirrors the [upstream example](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/express) and bootstraps a ready-to-run Express server.
+The starter mirrors the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express) and bootstraps a ready-to-run Express server.
 
 
 ### Step 2: Set your environment variables

--- a/x402/servers/typescript/hono.mdx
+++ b/x402/servers/typescript/hono.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Hono server in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/hono).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/hono).</Note>
 
 ### Step 1: Create a new server from the starter template
 
@@ -25,7 +25,7 @@ pnpm dlx @payai/x402-hono-starter@latest my-server
 bunx @payai/x402-hono-starter@latest my-server
 ```
 
-The starter mirrors the [upstream example](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/hono) and bootstraps a ready-to-run Hono server.
+The starter mirrors the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/hono) and bootstraps a ready-to-run Hono server.
 
 ### Step 2: Set your environment variables
 

--- a/x402/servers/typescript/nextjs.mdx
+++ b/x402/servers/typescript/nextjs.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Next.js app in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/coinbase/x402/tree/main/examples/typescript/fullstack/next). For the fastest setup, use [@payai/x402-next-starter](https://www.npmjs.com/package/@payai/x402-next-starter).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next). For the fastest setup, use [@payai/x402-next-starter](https://www.npmjs.com/package/@payai/x402-next-starter).</Note>
 
 ### Step 1: Create a new app
 
@@ -25,7 +25,7 @@ pnpm dlx @payai/x402-next-starter@latest my-server
 bunx @payai/x402-next-starter@latest my-server
 ```
 
-The starter mirrors the [upstream example](https://github.com/coinbase/x402/tree/main/examples/typescript/fullstack/next) and boostraps a ready-to-run NextJS app.
+The starter mirrors the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next) and boostraps a ready-to-run NextJS app.
 
 ### Step 2: Set your environment variables
 


### PR DESCRIPTION
## Summary
- Updated all `coinbase/x402` references to `x402-foundation/x402` across 22 doc files
- Covers GitHub URLs, Go import paths, `go get` commands, and prose labels
- Includes both current docs and v1 legacy docs

The upstream x402 project moved from `github.com/coinbase/x402` to `github.com/x402-foundation/x402`. The old import paths cause build failures for Go users following our guides (missing modules / unknown revisions).

## Test plan
- [ ] Verify all links resolve to the correct x402-foundation GitHub pages
- [ ] Confirm Go quickstart (`x402/servers/go/gin.mdx`) works end-to-end with updated import paths
- [ ] Spot-check that no `coinbase/x402` references remain (`grep -r "coinbase/x402" .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)