### PR TITLE
docs: update free tier to 10,000 settlements/month

### DIFF
--- a/onboarding/copywriter-onboarding.md
+++ b/onboarding/copywriter-onboarding.md
@@ -84,7 +84,7 @@ x402 is a payment protocol that enables **pay-per-use API transactions**. The na
 
 **Key features:**
 - Solana-first, multi-network support (Base, Polygon, SKALE, Avalanche, and more)
-- Free tier: Up to 1,000 settlements/month at no cost, no API key required
+- Free tier: Up to 10,000 settlements/month at no cost, no API key required
 - Beyond free tier: $0.001 per transaction
 - Credit system: 1 credit = 1 settled transaction, credits never expire
 - Merchants top up credits via the dashboard at merchant.payai.network

--- a/x402/facilitators/authentication.mdx
+++ b/x402/facilitators/authentication.mdx
@@ -10,7 +10,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 The [PayAI facilitator](https://facilitator.payai.network) authenticates merchants using short-lived **JWTs signed with Ed25519** (the EdDSA algorithm). If you use the `@payai/facilitator` TypeScript package, this is handled automatically. This guide explains the underlying protocol so you can implement authentication in **any language** without depending on PayAI packages.
 
 <Note>
-  Authentication is only required beyond the [free tier](/x402/facilitators/pricing) (1,000 settlements/month). Create a merchant account at [merchant.payai.network](https://merchant.payai.network) to get your API keys.
+  Authentication is only required beyond the [free tier](/x402/facilitators/pricing) (10,000 settlements/month). Create a merchant account at [merchant.payai.network](https://merchant.payai.network) to get your API keys.
 </Note>
 
 <Tip>

--- a/x402/facilitators/introduction.mdx
+++ b/x402/facilitators/introduction.mdx
@@ -68,7 +68,7 @@ This works immediately on the **free tier** — no API keys required.
 
 ## API key authentication
 
-When you're ready to scale beyond the free tier (1,000 settlements/month), create a merchant account at [merchant.payai.network](https://merchant.payai.network) to top up credits and get API keys. See [Pricing](/x402/facilitators/pricing) for details.
+When you're ready to scale beyond the free tier (10,000 settlements/month), create a merchant account at [merchant.payai.network](https://merchant.payai.network) to top up credits and get API keys. See [Pricing](/x402/facilitators/pricing) for details.
 
 Set these environment variables and `@payai/facilitator` will automatically authenticate your requests:
 

--- a/x402/facilitators/pricing.mdx
+++ b/x402/facilitators/pricing.mdx
@@ -12,7 +12,7 @@ The free tier remains free — no strings attached.
 <Card title="Free" icon="gift">
   **$0/month**
 
-  - Up to **1,000 settlements per month**
+  - Up to **10,000 settlements per month**
   - No API key required
 </Card>
 
@@ -46,7 +46,7 @@ At this pricing, the facilitator remains extremely builder friendly. It costs th
 
 ## Credit System
 
-To maintain access beyond 1,000 settlements/month, merchants log into a dashboard and top up credits.
+To maintain access beyond 10,000 settlements/month, merchants log into a dashboard and top up credits.
 
 - **1 credit = 1 settled transaction**
 - **Credits never expire**
@@ -64,7 +64,7 @@ To maintain access beyond 1,000 settlements/month, merchants log into a dashboar
 | | Free | Beyond Free |
 |---|---|---|
 | **Monthly cost** | $0 | $0.001 per transaction |
-| **Settlements included** | Up to 1,000/month | Unlimited (credit-based) |
+| **Settlements included** | Up to 10,000/month | Unlimited (credit-based) |
 | **API key required** | No | Yes |
 | **Credits** | Not required | 1 credit = 1 settlement |
 | **Credit expiry** | — | Never |
@@ -73,7 +73,7 @@ To maintain access beyond 1,000 settlements/month, merchants log into a dashboar
 ## How to get started
 
 1. Follow the [quickstart](/x402/quickstart) to start building — the free tier requires no API key
-2. When you're ready to scale beyond 1,000 settlements/month, create a merchant account at [merchant.payai.network](https://merchant.payai.network)
+2. When you're ready to scale beyond 10,000 settlements/month, create a merchant account at [merchant.payai.network](https://merchant.payai.network)
 3. Top up credits from the dashboard
 4. Get your API key ID and secret
 5. Set the environment variables in your server:


### PR DESCRIPTION
## Summary
- Updates all references to the free tier limit from 1,000 to 10,000 settlements/month
- Files updated: pricing.mdx, introduction.mdx, authentication.mdx, copywriter-onboarding.md
- Aligns with the recently updated PayAI facilitator limits

## Test plan
- [x] Verify pricing page shows 10,000 settlements in free tier card, comparison table, and getting started section
- [x] Verify introduction and authentication pages reference 10,000 settlements/month
- [x] Verify copywriter onboarding doc reflects updated limit