### PR TITLE
docs: remove upstream repo run instructions from client guides

### DIFF
--- a/x402/clients/go/http.mdx
+++ b/x402/clients/go/http.mdx
@@ -13,8 +13,6 @@ go mod init myclient
 go get github.com/x402-foundation/x402/go github.com/joho/godotenv
 ```
 
-To run from the x402 repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then `cd examples/go/clients/http`, copy `.env-example` to `.env`, and run `go run . mechanism-helper-registration` (or `go run . builder-pattern`).
-
 ### Step 2: Set your environment variables
 
 Your `.env` file should look like this:

--- a/x402/clients/python/httpx.mdx
+++ b/x402/clients/python/httpx.mdx
@@ -12,8 +12,6 @@ Make x402 payments with an httpx client in 2 minutes.
 pip install x402 httpx eth-account python-dotenv
 ```
 
-To run from the x402 repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the python examples root run the setup steps in the [httpx README](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/httpx), copy `.env-local` to `.env`, and run the example.
-
 ### Step 2: Set your environment variables
 
 Your `.env` file should look like this:

--- a/x402/clients/python/requests.mdx
+++ b/x402/clients/python/requests.mdx
@@ -12,8 +12,6 @@ Make x402 payments with a requests client in 2 minutes.
 pip install x402 requests eth-account python-dotenv
 ```
 
-To run from the x402 repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the python examples root follow the [requests example](https://github.com/x402-foundation/x402/tree/main/examples/python/clients/requests), copy `.env-local` to `.env`, and run the example.
-
 ### Step 2: Set your environment variables
 
 Your `.env` file should look like this:

--- a/x402/clients/typescript/axios.mdx
+++ b/x402/clients/typescript/axios.mdx
@@ -8,8 +8,6 @@ Make x402 payments with an Axios client in 2 minutes.
 
 ### Step 1: Create a new client
 
-Use the starter or run the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios) from the x402 repo.
-
 ##### npm (npx)
 ```bash
 npx @payai/x402-axios-starter@latest my-first-client
@@ -25,7 +23,7 @@ pnpm dlx @payai/x402-axios-starter@latest my-first-client
 bunx @payai/x402-axios-starter@latest my-first-client
 ```
 
-The starter mirrors the upstream example and bootstraps a ready-to-run Axios client. To run from the repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the typescript examples root run `pnpm install && pnpm build`, then `cd clients/axios`, copy `.env-local` to `.env`, and run `pnpm dev`.
+The starter mirrors the [upstream axios example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios) and bootstraps a ready-to-run Axios client.
 
 ### Step 2: Set your environment variables
 

--- a/x402/clients/typescript/fetch.mdx
+++ b/x402/clients/typescript/fetch.mdx
@@ -8,8 +8,6 @@ Make x402 payments with a Fetch client in 2 minutes.
 
 ### Step 1: Create a new client
 
-Use the starter or run the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/fetch) from the x402 repo.
-
 ##### npm (npx)
 ```bash
 npx @payai/x402-fetch-starter@latest my-first-client
@@ -25,7 +23,7 @@ pnpm dlx @payai/x402-fetch-starter@latest my-first-client
 bunx @payai/x402-fetch-starter@latest my-first-client
 ```
 
-The starter mirrors the upstream example and bootstraps a ready-to-run Fetch client. To run from the repo instead: clone [x402-foundation/x402](https://github.com/x402-foundation/x402), then from the typescript examples root run `pnpm install && pnpm build`, then `cd clients/fetch`, copy `.env-local` to `.env`, and run `pnpm dev`.
+The starter mirrors the [upstream fetch example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/fetch) and bootstraps a ready-to-run Fetch client.
 
 ### Step 2: Set your environment variables
 

--- a/x402/servers/typescript/nextjs.mdx
+++ b/x402/servers/typescript/nextjs.mdx
@@ -4,7 +4,7 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Next.js app in 2 minutes.
 
-<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next). For the fastest setup, use [@payai/x402-next-starter](https://www.npmjs.com/package/@payai/x402-next-starter).</Note>
+<Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next).</Note>
 
 ### Step 1: Create a new app
 


### PR DESCRIPTION
## Summary

- Removed step-by-step instructions for cloning and running the upstream x402-foundation/x402 repo from all client docs (axios, fetch, httpx, requests, Go http)
- Upstream examples are still linked via the `<Note>` at the top of each page for curious readers
- Removed redundant "Use the starter or run the upstream example from the x402 repo" sentence from axios and fetch docs
- Removed "For the fastest setup, use @payai/x402-next-starter" from the Next.js note (redundant since the page is already about the starter)

## Test plan

- [ ] Verify client pages (axios, fetch, httpx, requests, Go http) no longer include clone/run instructions
- [ ] Verify upstream example links in `<Note>` components are intact
- [ ] Verify Next.js note is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)