### PR TITLE
docs: add Arbitrum One and Arbitrum Sepolia to supported networks

### DIFF
--- a/snippets/supported-networks-table.mdx
+++ b/snippets/supported-networks-table.mdx
@@ -1,5 +1,7 @@
 | Network Name       | V1 Network String    | V2 CAIP-2 ID |
 | ------------------ | -------------------- | ------------ |
+| Arbitrum One       | `arbitrum`           | `eip155:42161` |
+| Arbitrum Sepolia   | `arbitrum-sepolia`   | `eip155:421614` |
 | Avalanche          | `avalanche`          | `eip155:43114` |
 | Avalanche Fuji     | `avalanche-fuji`     | `eip155:43113` |
 | Base               | `base`               | `eip155:8453` |


### PR DESCRIPTION
## Summary
Add Arbitrum One (`arbitrum` / `eip155:42161`) and Arbitrum Sepolia (`arbitrum-sepolia` / `eip155:421614`) rows to `snippets/supported-networks-table.mdx`, inserted alphabetically.

## Test plan
- [ ] Confirm the table renders correctly in Mintlify preview.