### PR TITLE
docs: require x402[evm,svm] extras in python client install steps

### DIFF
--- a/x402/clients/python/httpx.mdx
+++ b/x402/clients/python/httpx.mdx
@@ -9,8 +9,10 @@ Make x402 payments with an httpx client in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install x402 httpx eth-account python-dotenv
+pip install 'x402[evm,svm]' httpx eth-account python-dotenv
 ```
+
+<Note>The `[evm,svm]` extras pull in the EVM and SVM payment mechanisms used below. Without them, the `x402.mechanisms.evm` / `x402.mechanisms.svm` imports fail. Install only the extra you need (e.g. `'x402[svm]'`) if you're paying on a single network. The quotes keep shells like zsh from expanding the brackets.</Note>
 
 ### Step 2: Set your environment variables
 

--- a/x402/clients/python/requests.mdx
+++ b/x402/clients/python/requests.mdx
@@ -9,8 +9,10 @@ Make x402 payments with a requests client in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install x402 requests eth-account python-dotenv
+pip install 'x402[evm,svm]' requests eth-account python-dotenv
 ```
+
+<Note>The `[evm,svm]` extras pull in the EVM and SVM payment mechanisms used below. Without them, the `x402.mechanisms.evm` / `x402.mechanisms.svm` imports fail. Install only the extra you need (e.g. `'x402[svm]'`) if you're paying on a single network. The quotes keep shells like zsh from expanding the brackets.</Note>
 
 ### Step 2: Set your environment variables
 


### PR DESCRIPTION
## Problem

The Python httpx and requests client guides both import `x402.mechanisms.evm` and `x402.mechanisms.svm`, but the install steps only run `pip install x402 ...`. Those mechanism imports fail unless the matching extras are installed, so following the guide verbatim produces an `ImportError`:

```
ImportError: EVM signers require eth_account and web3. Install with: pip install x402[evm]
ImportError: SVM mechanism requires solana packages. Install with: pip install x402[svm]
```

## Fix

- Update the `pip install` command in both guides to `pip install 'x402[evm,svm]' ...`
- Add a note explaining what the extras provide, that you can install just one (e.g. `'x402[svm]'`) for a single network, and why the brackets are quoted (zsh globbing)

## Files

- `x402/clients/python/httpx.mdx`
- `x402/clients/python/requests.mdx`

Verified by following the httpx guide end-to-end against the live Solana echo merchant after the fix.