### PR TITLE
chore(docs): remove IoTeX from PayAI facilitator supported networks

### DIFF
--- a/onboarding/copywriter-onboarding.md
+++ b/onboarding/copywriter-onboarding.md
@@ -460,7 +460,6 @@ Our content is organized into four main pillars:
 - SKALE
 - Avalanche
 - Sei
-- IoTeX
 
 ### Ecosystem Projects
 

--- a/snippets/facilitators-table.mdx
+++ b/snippets/facilitators-table.mdx
@@ -1,3 +1,3 @@
 | Facilitator | URL | Networks |
 | ----------- | --- | -------- |
-| PayAI Facilitator | https://facilitator.payai.network | Base, Base Sepolia, Solana, Solana Devnet, Avalanche, IoTeX |
+| PayAI Facilitator | https://facilitator.payai.network | Base, Base Sepolia, Solana, Solana Devnet, Avalanche |

--- a/v1/x402/reference.mdx
+++ b/v1/x402/reference.mdx
@@ -492,11 +492,6 @@ Returns the list of payment schemes and networks supported by the facilitator.
     {
       "x402Version": 1,
       "scheme": "exact",
-      "network": "iotex"
-    },
-    {
-      "x402Version": 1,
-      "scheme": "exact",
       "network": "solana-devnet",
       "extra": {
         "feePayer": "address of facilitator"

--- a/x402/reference.mdx
+++ b/x402/reference.mdx
@@ -546,11 +546,6 @@ Returns the list of payment schemes and networks supported by the facilitator.
     {
       "x402Version": 2,
       "scheme": "exact",
-      "network": "iotex"
-    },
-    {
-      "x402Version": 2,
-      "scheme": "exact",
       "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
       "extra": {
         "feePayer": "address of facilitator"


### PR DESCRIPTION
## Summary

Removes **IoTeX** from the docs surfaces that advertise it as a PayAI Facilitator supported network. The facilitator does not support IoTeX (its settlement-worker for `iotex` throws `Unsupported network`), and the network was just removed from the facilitator deployment config in `infra-deployments` #9. These references were stale/inaccurate.

## Changes
- `snippets/facilitators-table.mdx` — drop `IoTeX` from the PayAI Facilitator networks column
- `onboarding/copywriter-onboarding.md` — remove `IoTeX` from the Supported Networks list
- `v1/x402/reference.mdx` & `x402/reference.mdx` — remove the `"network": "iotex"` entry from the example `/supported` responses

Note: `snippets/supported-networks-table.mdx` was already free of iotex/peaq/kiteai. No Peaq/KiteAI references existed in docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
