### PR TITLE
docs: send documentation analytics to PostHog

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -254,6 +254,10 @@
   "integrations": {
     "gtm": {
       "tagId": "GTM-N5V93RM6"
+    },
+    "posthog": {
+      "apiKey": "phc_R2aP3x5CY2NTFkjuMT3mmnxdB5WuSdwIKCj0kNWWZlv",
+      "apiHost": "https://us.i.posthog.com"
     }
   },
   "banner": {

--- a/docs.json
+++ b/docs.json
@@ -232,15 +232,15 @@
   },
   "contextual": {
     "options": [
-     "copy",
-     "view",
-     "chatgpt",
-     "claude",
-     "perplexity",
-     "mcp",
-     "cursor",
-     "vscode"
-   ]
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
   },
   "footer": {
     "socials": {
@@ -257,10 +257,11 @@
     },
     "posthog": {
       "apiKey": "phc_R2aP3x5CY2NTFkjuMT3mmnxdB5WuSdwIKCj0kNWWZlv",
-      "apiHost": "https://us.i.posthog.com"
+      "apiHost": "https://us.i.posthog.com",
+      "sessionRecording": true
     }
   },
   "banner": {
-      "content": "🎉 x402 is now live on Solana!"
+    "content": "🎉 x402 is now live on Solana!"
   }
 }


### PR DESCRIPTION
## What

Adds the PostHog integration to `docs.json` alongside the existing GTM container.

```json
"posthog": {
  "apiKey": "phc_R2aP…",
  "apiHost": "https://us.i.posthog.com",
  "sessionRecording": true
}
```

Points at project **341570** — the same project the merchant portal uses, per **Decision B** in the PostHog adoption plan ("one shared production project… one person timeline from landing → signup → activation").

## Why

Came out of the x402 starter audit. Docs traffic was the only acquisition signal with no self-serve access — answering "which pages drive merchants?" currently means a manual CSV pull from the Mintlify dashboard. This makes it queryable alongside portal events.

## Session recording: on

Enabled deliberately after checking the two things that would have argued against it.

**Cost is not a factor at this scale.** The portal runs 309 sessions per 30 days; docs would add roughly 1,000/month (5,695 human views over 90 days). PostHog's free tier is 5,000 recordings/month, so this lands around a quarter of it with the portal included.

**The masking concern is portal-specific.** The PostHog plan flags that default masking covers inputs only, so rendered text is captured — which matters on the portal, where API key reveal modals, wallet addresses and balances are on screen. Docs render documentation examples. Worth stating plainly: `docs.json` exposes **no masking controls** (only `apiKey`, `apiHost`, `sessionRecording`). That would be disqualifying on the portal; it's acceptable on public docs.

**Scope limit:** replay only captures the ~27% of docs traffic that executes JS.

## Notes

- `apiKey` is PostHog's **public project token** — write-only ingestion, designed to ship in client-side code.
- **Default ingestion host.** Decision D calls for the managed reverse proxy at `ph.payai.network`; that CNAME isn't live yet, so switching `apiHost` is a follow-up. Worth doing — the plan notes `/ingest`-style paths sit on adblock lists.
- Validated against the [Mintlify schema](https://mintlify.com/docs.json): `apiKey` is required and must match `^phc_`; `apiHost` and `sessionRecording` are optional. Full `docs.json` passes Draft 2020-12 validation.

## What this does and does not measure

**73% of docs traffic is AI** per the Mintlify export. PostHog fires from JS, so agents fetching `/llms.txt`, `/llms-full.txt` or `.md` execute nothing and are never captured — Mintlify's edge-level `aiViews` remains the fuller number.

But anything that *renders* the page is captured **and classified**: PostHog stamps `$virt_traffic_type` (Regular / Bot / AI Agent / Automation), `$virt_traffic_category` (`ai_crawler`, `ai_search`, `ai_assistant`, …), `$virt_bot_name` and `$virt_bot_operator` on every event. That gives per-operator agent attribution Mintlify's single `aiViews` bucket doesn't.

## Test plan

- [ ] Merge and confirm `$pageview` events arrive with `$host = docs.payai.network`
- [ ] Confirm portal events are unaffected (same project, new host dimension)
- [ ] Spot-check `$virt_traffic_type` breakdown on docs pageviews
- [ ] Confirm recordings appear and stay within the free tier