### PR TITLE
docs: replace starter scaffolds with direct install steps

### DIFF
--- a/v1/x402/clients/typescript/axios.mdx
+++ b/v1/x402/clients/typescript/axios.mdx
@@ -6,26 +6,12 @@ Make x402 payments with an Axios client in 2 minutes.
 
 <Note>You can find the full code for this example <a href="https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios" target="_blank">here</a>.</Note>
 
-### Step 1: Create a new client from the starter template
+### Step 1: Create a new client
 
-Use your favorite package manager.
-
-##### npm (npx)
-```bash
-npx @payai/x402-axios-starter my-first-client
-```
-
-##### pnpm
-```bash
-pnpm dlx @payai/x402-axios-starter my-first-client
-```
-
-##### bun
-```bash
-bunx @payai/x402-axios-starter my-first-client
-```
-
-The starter mirrors the upstream example and bootstraps a ready-to-run Axios client.
+<Warning>
+The `@payai/x402-*-starter` scaffolding packages are deprecated and no longer maintained.
+This V1 page is kept for reference only — follow the current [Axios guide](/x402/clients/typescript/axios) for up-to-date install steps.
+</Warning>
 
 ### Step 2: Set your environment variables
 

--- a/v1/x402/clients/typescript/fetch.mdx
+++ b/v1/x402/clients/typescript/fetch.mdx
@@ -6,27 +6,12 @@ Make x402 payments with a Fetch client in 2 minutes.
 
 <Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/0dfd3e683f1563543bd62a3ad84cbc6851d4054b/examples/typescript/clients/fetch).</Note>
 
-### Step 1: Create a new client from the starter template
+### Step 1: Create a new client
 
-Use your favorite package manager.
-
-##### npm (npx)
-```bash
-npx @payai/x402-fetch-starter my-first-client
-```
-
-##### pnpm
-```bash
-pnpm dlx @payai/x402-fetch-starter my-first-client
-```
-
-##### bun
-```bash
-bunx @payai/x402-fetch-starter my-first-client
-```
-
-The starter mirrors the upstream example and bootstraps a ready-to-run Fetch client.
-
+<Warning>
+The `@payai/x402-*-starter` scaffolding packages are deprecated and no longer maintained.
+This V1 page is kept for reference only — follow the current [Fetch guide](/x402/clients/typescript/fetch) for up-to-date install steps.
+</Warning>
 
 ### Step 2: Preview the client code
 

--- a/v1/x402/servers/typescript/express.mdx
+++ b/v1/x402/servers/typescript/express.mdx
@@ -6,27 +6,12 @@ Start accepting x402 payments in your Express server in 2 minutes.
 
 <Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express).</Note>
 
-### Step 1: Create a new server from the starter template
+### Step 1: Create a new server
 
-Use your favorite package manager.
-
-##### npm (npx)
-```bash
-npx @payai/x402-express-starter my-first-server
-```
-
-##### pnpm
-```bash
-pnpm dlx @payai/x402-express-starter my-first-server
-```
-
-##### bun
-```bash
-bunx @payai/x402-express-starter my-first-server
-```
-
-The starter mirrors the upstream example and bootstraps a ready-to-run Express server.
-
+<Warning>
+The `@payai/x402-*-starter` scaffolding packages are deprecated and no longer maintained.
+This V1 page is kept for reference only — follow the current [Express guide](/x402/servers/typescript/express) for up-to-date install steps.
+</Warning>
 
 ### Step 2: Set your environment variables
 

--- a/v1/x402/servers/typescript/nextjs.mdx
+++ b/v1/x402/servers/typescript/nextjs.mdx
@@ -4,31 +4,12 @@ import DiscordHelpCard from "/snippets/discord-help-card.mdx";
 
 Start accepting x402 payments in your Next.js app in 2 minutes.
 
-<Note>
-  For the fastest setup, use the official starter:
-  <a href="https://www.npmjs.com/package/@payai/x402-next-starter">@payai/x402-next-starter</a>.
-</Note>
+### Step 1: Create a new app
 
-### Step 1: Create a new app from the starter template
-
-Use your favorite package manager.
-
-##### npm (npx)
-```bash
-npx @payai/x402-next-starter my-first-app
-```
-
-##### pnpm
-```bash
-pnpm dlx @payai/x402-next-starter my-first-app
-```
-
-##### bun
-```bash
-bunx @payai/x402-next-starter my-first-app
-```
-
-The starter bootstraps a production-ready Next.js app with x402 payment middleware already wired up.
+<Warning>
+The `@payai/x402-*-starter` scaffolding packages are deprecated and no longer maintained.
+This V1 page is kept for reference only — follow the current [Next.js guide](/x402/servers/typescript/nextjs) for up-to-date install steps.
+</Warning>
 
 ### Step 2: Set your environment variables
 

--- a/x402/clients/typescript/axios.mdx
+++ b/x402/clients/typescript/axios.mdx
@@ -6,28 +6,39 @@ Make x402 payments with an Axios client in 2 minutes.
 
 <Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios).</Note>
 
-### Step 1: Create a new client
+### Step 1: Create a project and install dependencies
 
-##### npm (npx)
+Use your favorite package manager:
+
+##### npm
 ```bash
-npx @payai/x402-axios-starter@latest my-first-client
+mkdir my-first-client && cd my-first-client
+npm init -y && npm pkg set type=module
+npm install axios dotenv viem @solana/kit @scure/base @x402/axios @x402/evm @x402/svm
+npm install -D typescript tsx
 ```
 
 ##### pnpm
 ```bash
-pnpm dlx @payai/x402-axios-starter@latest my-first-client
+mkdir my-first-client && cd my-first-client
+pnpm init && pnpm pkg set type=module
+pnpm add axios dotenv viem @solana/kit @scure/base @x402/axios @x402/evm @x402/svm
+pnpm add -D typescript tsx
 ```
 
 ##### bun
 ```bash
-bunx @payai/x402-axios-starter@latest my-first-client
+mkdir my-first-client && cd my-first-client
+bun init -y
+bun add axios dotenv viem @solana/kit @scure/base @x402/axios @x402/evm @x402/svm
+bun add -d typescript
 ```
 
-The starter mirrors the [upstream axios example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios) and bootstraps a ready-to-run Axios client.
+This is the same dependency set as the [upstream Axios example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/axios).
 
 ### Step 2: Set your environment variables
 
-Open your generated project's `.env` and set the following:
+Create a `.env` file in the project root and set the following:
 
 - `RESOURCE_SERVER_URL`: Base URL of the server to call (e.g. http://localhost:4021)
 - `ENDPOINT_PATH`: Path to a paid endpoint (e.g. /weather)
@@ -43,7 +54,7 @@ ENDPOINT_PATH=/weather
 
 ### Step 3: Preview the client code
 
-This is the `index.ts` the starter generates. It loads your env, creates an x402 client with EVM and SVM schemes, wraps Axios with `wrapAxiosWithPayment`, calls your endpoint, and logs the response body and payment settlement from the `PAYMENT-RESPONSE` header.
+Create `index.ts`: It loads your env, creates an x402 client with EVM and SVM schemes, wraps Axios with `wrapAxiosWithPayment`, calls your endpoint, and logs the response body and payment settlement from the `PAYMENT-RESPONSE` header.
 
 ```ts
 import { config } from "dotenv";
@@ -107,7 +118,7 @@ main().catch(error => {
 ### Step 4: Run the client
 
 ```bash
-npm run dev
+npx tsx index.ts
 ```
 
 <Check>

--- a/x402/clients/typescript/fetch.mdx
+++ b/x402/clients/typescript/fetch.mdx
@@ -6,28 +6,39 @@ Make x402 payments with a Fetch client in 2 minutes.
 
 <Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/fetch).</Note>
 
-### Step 1: Create a new client
+### Step 1: Create a project and install dependencies
 
-##### npm (npx)
+Use your favorite package manager:
+
+##### npm
 ```bash
-npx @payai/x402-fetch-starter@latest my-first-client
+mkdir my-first-client && cd my-first-client
+npm init -y && npm pkg set type=module
+npm install dotenv viem @solana/kit @scure/base @x402/evm @x402/fetch @x402/svm
+npm install -D typescript tsx
 ```
 
 ##### pnpm
 ```bash
-pnpm dlx @payai/x402-fetch-starter@latest my-first-client
+mkdir my-first-client && cd my-first-client
+pnpm init && pnpm pkg set type=module
+pnpm add dotenv viem @solana/kit @scure/base @x402/evm @x402/fetch @x402/svm
+pnpm add -D typescript tsx
 ```
 
 ##### bun
 ```bash
-bunx @payai/x402-fetch-starter@latest my-first-client
+mkdir my-first-client && cd my-first-client
+bun init -y
+bun add dotenv viem @solana/kit @scure/base @x402/evm @x402/fetch @x402/svm
+bun add -d typescript
 ```
 
-The starter mirrors the [upstream fetch example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/fetch) and bootstraps a ready-to-run Fetch client.
+This is the same dependency set as the [upstream Fetch example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/fetch).
 
 ### Step 2: Set your environment variables
 
-Open your generated project's `.env` and set the following:
+Create a `.env` file in the project root and set the following:
 
 - `EVM_PRIVATE_KEY`: Hex EVM private key of the paying account
 - `SVM_PRIVATE_KEY`: Base58 Solana private key of the paying account
@@ -43,7 +54,7 @@ ENDPOINT_PATH=/weather
 
 ### Step 3: Preview the client code
 
-This is the `index.ts` the starter generates. It loads your env, creates an x402 client with EVM and SVM schemes, wraps `fetch` with `wrapFetchWithPayment`, calls your endpoint, and logs the response body and payment settlement from the `PAYMENT-RESPONSE` header.
+Create `index.ts`: It loads your env, creates an x402 client with EVM and SVM schemes, wraps `fetch` with `wrapFetchWithPayment`, calls your endpoint, and logs the response body and payment settlement from the `PAYMENT-RESPONSE` header.
 
 ```ts
 import { config } from "dotenv";
@@ -106,7 +117,7 @@ main().catch(error => {
 ### Step 4: Run the client
 
 ```bash
-npm run dev
+npx tsx index.ts
 ```
 
 <Check>

--- a/x402/facilitators/authentication.mdx
+++ b/x402/facilitators/authentication.mdx
@@ -14,7 +14,7 @@ The [PayAI facilitator](https://facilitator.payai.network) authenticates merchan
 </Note>
 
 <Tip>
-  If you're using one of the TypeScript server guides or starter kits ([Express](/x402/servers/typescript/express), [Hono](/x402/servers/typescript/hono), [Next.js](/x402/servers/typescript/nextjs)), facilitator authentication is already built in. Just set the `PAYAI_API_KEY_ID` and `PAYAI_API_KEY_SECRET` environment variables and the middleware handles the rest. Refer to those guides for setup instructions.
+  If you're following one of the TypeScript server guides ([Express](/x402/servers/typescript/express), [Hono](/x402/servers/typescript/hono), [Next.js](/x402/servers/typescript/nextjs)), facilitator authentication is already built in. Just set the `PAYAI_API_KEY_ID` and `PAYAI_API_KEY_SECRET` environment variables and the middleware handles the rest. Refer to those guides for setup instructions.
 </Tip>
 
 ## API key structure

--- a/x402/facilitators/pricing.mdx
+++ b/x402/facilitators/pricing.mdx
@@ -83,7 +83,7 @@ PAYAI_API_KEY_ID=your-key-id
 PAYAI_API_KEY_SECRET=your-key-secret
 ```
 
-If you're using `@payai/facilitator` (included in all PayAI starter templates), your server will automatically authenticate with the facilitator — no code changes needed.
+If you're using `@payai/facilitator` (used throughout the TypeScript server guides), your server will automatically authenticate with the facilitator — no code changes needed.
 
 ```typescript
 import { facilitator } from "@payai/facilitator";

--- a/x402/quickstart.mdx
+++ b/x402/quickstart.mdx
@@ -62,7 +62,7 @@ Choose your language and framework below to get started.
 
 ## Facilitator
 
-All PayAI starter templates include `@payai/facilitator`, which automatically connects to the PayAI facilitator at `https://facilitator.payai.network`. No manual URL configuration needed.
+The TypeScript guides use `@payai/facilitator`, which automatically connects to the PayAI facilitator at `https://facilitator.payai.network`. No manual URL configuration needed.
 
 ```typescript
 import { facilitator } from "@payai/facilitator";

--- a/x402/servers/typescript/express.mdx
+++ b/x402/servers/typescript/express.mdx
@@ -6,42 +6,50 @@ Start accepting x402 payments in your Express server in 2 minutes.
 
 <Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express).</Note>
 
-### Step 1: Create a new server from the starter template
+### Step 1: Create a project and install dependencies
 
 Use your favorite package manager:
 
-##### npm (npx)
+##### npm
 ```bash
-npx @payai/x402-express-starter@latest my-server
+mkdir my-server && cd my-server
+npm init -y && npm pkg set type=module
+npm install express dotenv @payai/facilitator @x402/core @x402/evm @x402/express @x402/extensions @x402/svm
+npm install -D typescript tsx @types/express
 ```
 
 ##### pnpm
 ```bash
-pnpm dlx @payai/x402-express-starter@latest my-server
+mkdir my-server && cd my-server
+pnpm init && pnpm pkg set type=module
+pnpm add express dotenv @payai/facilitator @x402/core @x402/evm @x402/express @x402/extensions @x402/svm
+pnpm add -D typescript tsx @types/express
 ```
 
 ##### bun
 ```bash
-bunx @payai/x402-express-starter@latest my-server
+mkdir my-server && cd my-server
+bun init -y
+bun add express dotenv @payai/facilitator @x402/core @x402/evm @x402/express @x402/extensions @x402/svm
+bun add -d typescript @types/express
 ```
 
-The starter mirrors the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express) and bootstraps a ready-to-run Express server.
-
+This is the same dependency set as the [upstream Express example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express).
 
 ### Step 2: Set your environment variables
 
-Open your generated project's `.env` and set:
+Create a `.env` file in the project root and set:
 
 ```env
 EVM_ADDRESS=0x...   # EVM wallet address to receive payments
 SVM_ADDRESS=...    # Solana wallet address to receive payments
 ```
 
-<Tip>The starter uses `@payai/facilitator` which automatically connects to the PayAI facilitator — no URL configuration needed.</Tip>
+<Tip>`@payai/facilitator` automatically connects to the PayAI facilitator — no URL configuration needed.</Tip>
 
 ### Step 3: Preview the server code
 
-This is the `index.ts` the starter generates. It loads your env, applies the x402 payment middleware, defines example routes, and logs the server URL.
+Create `index.ts`: It loads your env, applies the x402 payment middleware, defines example routes, and logs the server URL.
 
 ```ts
 import { config } from "dotenv";
@@ -110,7 +118,7 @@ app.listen(4021, () => {
 ### Step 4: Run the server
 
 ```bash
-npm run dev
+npx tsx index.ts
 ```
 
 <Check>
@@ -123,7 +131,7 @@ You can test payments against your server locally by following the [fetch exampl
 
 ## Going to production
 
-The starter works on the **free tier** out of the box — no API keys required.
+This setup works on the **free tier** out of the box — no API keys required.
 
 When you're ready for production, create a merchant account at [merchant.payai.network](https://merchant.payai.network), get your API keys, and add them to your `.env`:
 

--- a/x402/servers/typescript/hono.mdx
+++ b/x402/servers/typescript/hono.mdx
@@ -6,41 +6,50 @@ Start accepting x402 payments in your Hono server in 2 minutes.
 
 <Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/hono).</Note>
 
-### Step 1: Create a new server from the starter template
+### Step 1: Create a project and install dependencies
 
 Use your favorite package manager:
 
-##### npm (npx)
+##### npm
 ```bash
-npx @payai/x402-hono-starter@latest my-server
+mkdir my-server && cd my-server
+npm init -y && npm pkg set type=module
+npm install hono @hono/node-server dotenv @payai/facilitator @x402/core @x402/evm @x402/extensions @x402/hono @x402/svm
+npm install -D typescript tsx
 ```
 
 ##### pnpm
 ```bash
-pnpm dlx @payai/x402-hono-starter@latest my-server
+mkdir my-server && cd my-server
+pnpm init && pnpm pkg set type=module
+pnpm add hono @hono/node-server dotenv @payai/facilitator @x402/core @x402/evm @x402/extensions @x402/hono @x402/svm
+pnpm add -D typescript tsx
 ```
 
 ##### bun
 ```bash
-bunx @payai/x402-hono-starter@latest my-server
+mkdir my-server && cd my-server
+bun init -y
+bun add hono @hono/node-server dotenv @payai/facilitator @x402/core @x402/evm @x402/extensions @x402/hono @x402/svm
+bun add -d typescript
 ```
 
-The starter mirrors the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/hono) and bootstraps a ready-to-run Hono server.
+This is the same dependency set as the [upstream Hono example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/hono).
 
 ### Step 2: Set your environment variables
 
-Open your generated project's `.env` and set:
+Create a `.env` file in the project root and set:
 
 ```env
 EVM_ADDRESS=0x...   # EVM wallet address to receive payments
 SVM_ADDRESS=...    # Solana wallet address to receive payments
 ```
 
-<Tip>The starter uses `@payai/facilitator` which automatically connects to the PayAI facilitator — no URL configuration needed.</Tip>
+<Tip>`@payai/facilitator` automatically connects to the PayAI facilitator — no URL configuration needed.</Tip>
 
 ### Step 3: Preview the server code
 
-This is the `index.ts` the starter generates. It loads your env, applies the x402 payment middleware, defines example routes, and logs the server URL.
+Create `index.ts`: It loads your env, applies the x402 payment middleware, defines example routes, and logs the server URL.
 
 ```ts
 import { config } from "dotenv";
@@ -113,7 +122,7 @@ console.log(`Server listening at http://localhost:4021`);
 ### Step 4: Run the server
 
 ```bash
-npm run dev
+npx tsx index.ts
 ```
 
 <Check>
@@ -129,7 +138,7 @@ You can test payments against your server locally by:
 
 ## Going to production
 
-The starter works on the **free tier** out of the box — no API keys required.
+This setup works on the **free tier** out of the box — no API keys required.
 
 When you're ready for production, create a merchant account at [merchant.payai.network](https://merchant.payai.network), get your API keys, and add them to your `.env`:
 

--- a/x402/servers/typescript/nextjs.mdx
+++ b/x402/servers/typescript/nextjs.mdx
@@ -6,37 +6,28 @@ Start accepting x402 payments in your Next.js app in 2 minutes.
 
 <Note>You can find the full code for this example [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next).</Note>
 
-### Step 1: Create a new app
+### Step 1: Create an app and install dependencies
 
-Use your favorite package manager:
+Scaffold a Next.js app, then add the x402 packages:
 
-##### npm (npx)
 ```bash
-npx @payai/x402-next-starter@latest my-server
+npx create-next-app@latest my-app --typescript --app
+cd my-app
+npm install @payai/facilitator @x402/core @x402/evm @x402/extensions @x402/next @x402/paywall @x402/svm
 ```
 
-##### pnpm
-```bash
-pnpm dlx @payai/x402-next-starter@latest my-server
-```
-
-##### bun
-```bash
-bunx @payai/x402-next-starter@latest my-server
-```
-
-The starter mirrors the [upstream example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next) and boostraps a ready-to-run NextJS app.
+This is the same dependency set as the [upstream Next.js example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next).
 
 ### Step 2: Set your environment variables
 
-Copy the example env and fill in your values (e.g. `cp .env-local .env` or `cp env.example .env.local`).
+Create a `.env.local` file in the project root and fill in your values.
 
 ```env
 EVM_ADDRESS=0x...   # EVM wallet address to receive payments
 SVM_ADDRESS=...    # Solana wallet address to receive payments
 ```
 
-<Tip>The starter uses `@payai/facilitator` which automatically connects to the PayAI facilitator — no URL configuration needed.</Tip>
+<Tip>`@payai/facilitator` automatically connects to the PayAI facilitator — no URL configuration needed.</Tip>
 
 ### Step 3: Explore the app structure
 
@@ -192,13 +183,13 @@ npm run dev
 
 ### Step 6: Test the server
 
-The starter includes a built-in paywall at the home page. Navigate to http://localhost:3000 to test payments directly.
+The example includes a built-in paywall at the home page. Navigate to http://localhost:3000 to test payments directly.
 
 You can also test programmatically by following the [fetch example](/x402/clients/typescript/fetch) or [axios example](/x402/clients/typescript/axios).
 
 ## Going to production
 
-The starter works on the **free tier** out of the box — no API keys required.
+This setup works on the **free tier** out of the box — no API keys required.
 
 When you're ready for production, create a merchant account at [merchant.payai.network](https://merchant.payai.network), get your API keys, and add them to your `.env`:
 


### PR DESCRIPTION
Part of the x402 starter wind-down. The five `@payai/x402-*-starter` packages are being deprecated; this removes every instruction telling readers to run them.

## The change is smaller than it sounds

Every affected page already printed the complete working code two steps below the `npx` block. The scaffold was a shortcut sitting on content that stands without it — so this deletes a code fence and adjusts the surrounding prose, rather than rewriting the guides.

**Current guides** (express, hono, nextjs, fetch, axios) — Step 1 now creates a project and installs dependencies directly. Dependency sets are taken verbatim from each starter's `template/package.json`, minus the lint/format tooling the scaffold added. Run commands go from `npm run dev` to `npx tsx index.ts`, since there's no longer a generated package script.

**V1 pages** — scaffold steps replaced with a deprecation warning pointing at the current guide. These are legacy reference and took 32 views between them over 90 days.

**Prose** in `quickstart`, `pricing` and `authentication` that described the starters as the install path.

## Verified

Followed the rewritten Express page verbatim — install, write `index.ts`, `npx tsx index.ts` — and got a valid 402 with both Base Sepolia and Solana offers:

```
HTTP/1.1 402 Payment Required
PAYMENT-REQUIRED: …eip155:84532… solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1…
```

One thing worth knowing: a fresh install resolves **Express 5.2.1**, where the starter pinned `^4.18.2`. The example works unchanged on 5.x — but this is the first time the docs path isn't pinned to whatever the starter froze.

## Not addressed here

The hardcoded port 4021 in the example (no `PORT` override) is inherited from upstream and left alone.

Separately: the traffic data suggests these framework tutorials are the wrong shape entirely — 43 such pages take 9.7% of docs traffic but account for 30% of commits to this repo. Proposing a collapse to a single "use the upstream example + this one PayAI change" page in a follow-up; this PR only makes the current pages correct.