### PR TITLE
docs: refresh fetch and axios examples to current upstream

### DIFF
--- a/x402/clients/typescript/axios.mdx
+++ b/x402/clients/typescript/axios.mdx
@@ -52,15 +52,23 @@ RESOURCE_SERVER_URL=http://localhost:4021
 ENDPOINT_PATH=/weather
 ```
 
+Optionally set `EVM_RPC_URL` to a JSON-RPC endpoint. When present, the client can perform
+onchain reads, which enables gas-sponsoring extensions:
+
+```env
+EVM_RPC_URL=
+```
+
 ### Step 3: Preview the client code
 
-Create `index.ts`: It loads your env, creates an x402 client with EVM and SVM schemes, wraps Axios with `wrapAxiosWithPayment`, calls your endpoint, and logs the response body and payment settlement from the `PAYMENT-RESPONSE` header.
+Create `index.ts`: It loads your env, builds an `x402Client` and registers the exact and `upto` EVM schemes plus exact SVM, wraps Axios with `wrapAxiosWithPayment`, calls your endpoint, and prints the parsed payment result via `x402HTTPClient.parsePaymentResult`.
 
 ```ts
 import { config } from "dotenv";
 import { x402Client, wrapAxiosWithPayment, x402HTTPClient } from "@x402/axios";
-import { registerExactEvmScheme } from "@x402/evm/exact/client";
-import { registerExactSvmScheme } from "@x402/svm/exact/client";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { UptoEvmScheme } from "@x402/evm/upto/client";
+import { ExactSvmScheme } from "@x402/svm/exact/client";
 import { privateKeyToAccount } from "viem/accounts";
 import { createKeyPairSignerFromBytes } from "@solana/kit";
 import { base58 } from "@scure/base";
@@ -70,6 +78,7 @@ config();
 
 const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
 const svmPrivateKey = process.env.SVM_PRIVATE_KEY as string;
+const evmRpcUrl = process.env.EVM_RPC_URL;
 const baseURL = process.env.RESOURCE_SERVER_URL || "http://localhost:4021";
 const endpointPath = process.env.ENDPOINT_PATH || "/weather";
 const url = `${baseURL}${endpointPath}`;
@@ -77,36 +86,36 @@ const url = `${baseURL}${endpointPath}`;
 /**
  * Example demonstrating how to use @x402/axios to make requests to x402-protected endpoints.
  *
- * This uses the helper registration functions from @x402/evm and @x402/svm to register
- * all supported networks for both v1 and v2 protocols.
+ * Uses the builder pattern to register payment schemes directly.
  *
  * Required environment variables:
  * - EVM_PRIVATE_KEY: The private key of the EVM signer
  * - SVM_PRIVATE_KEY: The private key of the SVM signer
+ *
+ * Optional environment variables:
+ * - EVM_RPC_URL: JSON-RPC endpoint for on-chain reads (enables gas sponsoring extensions)
  */
 async function main(): Promise<void> {
   const evmSigner = privateKeyToAccount(evmPrivateKey);
   const svmSigner = await createKeyPairSignerFromBytes(base58.decode(svmPrivateKey));
+  const rpcOptions = evmRpcUrl ? { rpcUrl: evmRpcUrl } : undefined;
 
   const client = new x402Client();
-  registerExactEvmScheme(client, { signer: evmSigner });
-  registerExactSvmScheme(client, { signer: svmSigner });
+  client.register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions));
+  client.register("eip155:*", new UptoEvmScheme(evmSigner, rpcOptions));
+  client.register("solana:*", new ExactSvmScheme(svmSigner));
 
   const api = wrapAxiosWithPayment(axios.create(), client);
+  const httpClient = new x402HTTPClient(client);
 
   console.log(`Making request to: ${url}\n`);
   const response = await api.get(url);
-  const body = response.data;
-  console.log("Response body:", body);
-
-  if (response.status < 400) {
-    const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(
-      name => response.headers[name.toLowerCase()],
-    );
-    console.log("\nPayment response:", paymentResponse);
-  } else {
-    console.log(`\nNo payment settled (response status: ${response.status})`);
-  }
+  const result = httpClient.parsePaymentResult({
+    status: response.status,
+    getHeader: name => response.headers[name.toLowerCase()],
+    body: response.data,
+  });
+  console.dir(result, { depth: null });
 }
 
 main().catch(error => {

--- a/x402/clients/typescript/fetch.mdx
+++ b/x402/clients/typescript/fetch.mdx
@@ -52,15 +52,23 @@ RESOURCE_SERVER_URL=http://localhost:4021
 ENDPOINT_PATH=/weather
 ```
 
+Optionally set `EVM_RPC_URL` to a JSON-RPC endpoint. When present, the client can perform
+onchain reads, which enables gas-sponsoring extensions:
+
+```env
+EVM_RPC_URL=
+```
+
 ### Step 3: Preview the client code
 
-Create `index.ts`: It loads your env, creates an x402 client with EVM and SVM schemes, wraps `fetch` with `wrapFetchWithPayment`, calls your endpoint, and logs the response body and payment settlement from the `PAYMENT-RESPONSE` header.
+Create `index.ts`: It loads your env, builds an `x402Client` and registers the exact and `upto` EVM schemes plus exact SVM, wraps `fetch` with `wrapFetchWithPayment`, calls your endpoint, and prints the parsed payment result via `x402HTTPClient.processResponse`.
 
 ```ts
 import { config } from "dotenv";
 import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
-import { registerExactEvmScheme } from "@x402/evm/exact/client";
-import { registerExactSvmScheme } from "@x402/svm/exact/client";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { UptoEvmScheme } from "@x402/evm/upto/client";
+import { ExactSvmScheme } from "@x402/svm/exact/client";
 import { privateKeyToAccount } from "viem/accounts";
 import { createKeyPairSignerFromBytes } from "@solana/kit";
 import { base58 } from "@scure/base";
@@ -69,6 +77,7 @@ config();
 
 const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
 const svmPrivateKey = process.env.SVM_PRIVATE_KEY as string;
+const evmRpcUrl = process.env.EVM_RPC_URL;
 const baseURL = process.env.RESOURCE_SERVER_URL || "http://localhost:4021";
 const endpointPath = process.env.ENDPOINT_PATH || "/weather";
 const url = `${baseURL}${endpointPath}`;
@@ -76,36 +85,32 @@ const url = `${baseURL}${endpointPath}`;
 /**
  * Example demonstrating how to use @x402/fetch to make requests to x402-protected endpoints.
  *
- * This uses the helper registration functions from @x402/evm and @x402/svm to register
- * all supported networks for both v1 and v2 protocols.
+ * Uses the builder pattern to register payment schemes directly.
  *
  * Required environment variables:
  * - EVM_PRIVATE_KEY: The private key of the EVM signer
  * - SVM_PRIVATE_KEY: The private key of the SVM signer
+ *
+ * Optional environment variables:
+ * - EVM_RPC_URL: JSON-RPC endpoint for onchain reads (enables gas sponsoring extensions)
  */
 async function main(): Promise<void> {
   const evmSigner = privateKeyToAccount(evmPrivateKey);
   const svmSigner = await createKeyPairSignerFromBytes(base58.decode(svmPrivateKey));
+  const rpcOptions = evmRpcUrl ? { rpcUrl: evmRpcUrl } : undefined;
 
   const client = new x402Client();
-  registerExactEvmScheme(client, { signer: evmSigner });
-  registerExactSvmScheme(client, { signer: svmSigner });
+  client.register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions));
+  client.register("eip155:*", new UptoEvmScheme(evmSigner, rpcOptions));
+  client.register("solana:*", new ExactSvmScheme(svmSigner));
 
   const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+  const httpClient = new x402HTTPClient(client);
 
   console.log(`Making request to: ${url}\n`);
   const response = await fetchWithPayment(url, { method: "GET" });
-  const body = await response.json();
-  console.log("Response body:", body);
-
-  if (response.ok) {
-    const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>
-      response.headers.get(name),
-    );
-    console.log("\nPayment response:", JSON.stringify(paymentResponse, null, 2));
-  } else {
-    console.log(`\nNo payment settled (response status: ${response.status})`);
-  }
+  const result = await httpClient.processResponse(response);
+  console.dir(result, { depth: null });
 }
 
 main().catch(error => {


### PR DESCRIPTION
Targets `docs/retire-starters` (#47) because it edits the same two files. Sits **parallel to #48**, not stacked on it — the file sets are disjoint. Retarget to `main` once #47 merges.

## What drifted

Upstream reworked both client examples on **2026-06-05** and our copies didn't follow:

- helper registration → **builder pattern** (`client.register("eip155:*", new ExactEvmScheme(...))`)
- added **`UptoEvmScheme`** alongside `ExactEvmScheme`
- added optional **`EVM_RPC_URL`** for onchain reads, enabling gas-sponsoring extensions
- response handling moved to `processResponse` / `parsePaymentResult`

## Nothing was broken

Worth being precise, since "stale docs" usually implies breakage. It didn't:

- Both the old and new variants **typecheck clean against `@x402/*` 2.21.0** — two minors past anything our docs referenced
- `@x402/evm/exact/client` still exports **both** `ExactEvmScheme` and `registerExactEvmScheme`
- There are no version pins in the example code; the install steps pull latest

The actual cost of the drift was **feature coverage** — our pages showed no `upto` support and no gas sponsoring.

## Verification

| check | result |
|---|---|
| `tsc --noEmit` vs `@x402/*` 2.21.0, both pages | exit 0 |
| runtime: client construction + scheme registration + wrapping | reaches network layer |
| failure mode | `ECONNREFUSED` only — no API errors |
| code block vs upstream `index.ts` | byte-identical, both files |

Runtime check used a locally generated throwaway Ed25519 keypair with no funds, pointed at a dead port. Nothing on-chain.

## Note on scope

Client examples carry **no PayAI delta** — a buyer talks to no facilitator, so these are pure upstream. That's unlike the server pages, where the whole delta is a 3-line facilitator swap.

`x402/servers/typescript/nextjs.mdx` also uses `registerExactEvmScheme`, but the **server-side** variant, which still exists and is still valid. Left alone — out of scope here.