### PR TITLE
docs: declare bazaar discovery on the Express and Hono examples

### DIFF
--- a/x402/servers/typescript/express.mdx
+++ b/x402/servers/typescript/express.mdx
@@ -58,6 +58,7 @@ import { paymentMiddleware, x402ResourceServer } from "@x402/express";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
 import { ExactSvmScheme } from "@x402/svm/exact/server";
 import { HTTPFacilitatorClient } from "@x402/core/server";
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
 import { facilitator } from "@payai/facilitator";
 
 config();
@@ -93,6 +94,20 @@ app.use(
         ],
         description: "Weather data",
         mimeType: "application/json",
+        serviceName: "Weather API",
+        tags: ["weather", "api"],
+        extensions: {
+          ...declareDiscoveryExtension({
+            output: {
+              example: {
+                report: {
+                  weather: "sunny",
+                  temperature: 70,
+                },
+              },
+            },
+          }),
+        },
       },
     },
     new x402ResourceServer(facilitatorClient)

--- a/x402/servers/typescript/hono.mdx
+++ b/x402/servers/typescript/hono.mdx
@@ -57,6 +57,7 @@ import { paymentMiddleware, x402ResourceServer } from "@x402/hono";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
 import { ExactSvmScheme } from "@x402/svm/exact/server";
 import { HTTPFacilitatorClient } from "@x402/core/server";
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
 import { facilitator } from "@payai/facilitator";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
@@ -94,6 +95,20 @@ app.use(
         ],
         description: "Weather data",
         mimeType: "application/json",
+        serviceName: "Weather API",
+        tags: ["weather", "api"],
+        extensions: {
+          ...declareDiscoveryExtension({
+            output: {
+              example: {
+                report: {
+                  weather: "sunny",
+                  temperature: 70,
+                },
+              },
+            },
+          }),
+        },
       },
     },
     new x402ResourceServer(facilitatorClient)


### PR DESCRIPTION
Follow-up to #50. Brings both server pages in line with the Next.js example, so all three TypeScript merchant guides declare their routes to the bazaar by default.

## Approach

Uses upstream's own idiom, lifted from [`examples/typescript/servers/advanced/bazaar.ts`](https://github.com/x402-foundation/x402/blob/main/examples/typescript/servers/advanced/bazaar.ts) rather than invented here — `declareDiscoveryExtension` in the route's `extensions`, plus `serviceName` and `tags` for the catalog listing. The output example matches what the handler actually returns.

`@x402/extensions` was already in both install lists, so Step 1 is unchanged.

## Verification

Both pages typecheck clean against `@x402/*` 2.21.0, and both boot and return a 402 whose `PAYMENT-REQUIRED` carries the discovery payload:

```json
"resource": {
  "serviceName": "Weather API",
  "tags": ["weather", "api"]
},
"extensions": {
  "bazaar": {
    "info": {
      "input":  { "type": "http", "method": "GET", "queryParams": {} },
      "output": { "type": "json", "example": { "report": { "weather": "sunny", "temperature": 70 } } }
    },
    "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", ... }
  }
}
```

Identical on both, with both networks still offered (`eip155:84532` and `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`).

## Tradeoff worth naming

**This is a second PayAI delta on these pages.** Upstream's `express` and `hono` examples do *not* declare discovery — only its Next.js and `advanced/bazaar` examples do. So a future upstream sync now has to preserve two deltas here (the facilitator swap and this block) rather than one.

That's a real, if small, increase in the maintenance surface — and it's an argument for the code-compiling CI check over a plain upstream diff, since a diff will now show more expected-divergence noise on these two pages.