### PR TITLE
ci: schedule the weekly checks around upstream's release rhythm

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -10,10 +10,11 @@ on:
   push:
     branches: [main]
   schedule:
-    # Weekly. The examples pin nothing, so they resolve whatever @x402/* is
-    # current — this catches an upstream release breaking them even when no
-    # docs change was made.
-    - cron: "0 6 * * 1"
+    # Tuesday morning UTC. Upstream publishes @x402/* mostly on Fridays (49%)
+    # with Monday second (25%); a Tuesday run covers both clusters in one pass.
+    # The examples pin nothing — they resolve whatever @x402/* is current — so
+    # this catches a release breaking them even when no docs change was made.
+    - cron: "0 6 * * 2"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -3,9 +3,12 @@ name: Sync upstream examples
 # Upstream touches these example files a handful of times a year, so this runs
 # weekly rather than continuously. A previous hourly sync on the starter repos
 # burned ~1,600 runs a month and shipped nothing; don't repeat that.
+#
+# Tuesday morning UTC, an hour after the compile check, so both the Friday and
+# Monday release clusters are covered by a single weekly pass.
 on:
   schedule:
-    - cron: "0 7 * * 1"
+    - cron: "0 7 * * 2"
   workflow_dispatch:
 
 permissions:

--- a/scripts/check_live_payment.py
+++ b/scripts/check_live_payment.py
@@ -60,6 +60,53 @@ def prepare(page, d, extra_env):
     return d
 
 
+FACILITATOR_SUPPORTED = "https://facilitator.payai.network/supported"
+
+
+def diagnose_failure(client_output):
+    """Say which repo to go and look in.
+
+    A failed payment has two very different causes, and the client output alone
+    does not distinguish them:
+
+      * our documented example is wrong, or
+      * upstream shipped a protocol change and the PayAI facilitator has not
+        absorbed it yet.
+
+    The second is real: the facilitator runs PayAI's own @payai/x402-* line,
+    which is versioned and released separately from upstream's @x402/*. So ask
+    the facilitator what it currently supports and compare against what the
+    documented example just offered.
+    """
+    offered = sorted(set(re.findall(r"network: '([^']+)'", client_output)))
+    try:
+        with urllib.request.urlopen(FACILITATOR_SUPPORTED, timeout=20) as r:
+            kinds = json.load(r).get("kinds", [])
+        supported = {(k.get("scheme"), k.get("network")) for k in kinds}
+    except Exception as e:
+        return f"    (could not reach {FACILITATOR_SUPPORTED} to diagnose: {e})"
+
+    if not offered:
+        return "    Could not read the offered networks from the client output."
+
+    unsupported = [n for n in offered if not any(net == n for _, net in supported)]
+    lines = [f"    example offered: {', '.join(offered)}"]
+    if unsupported:
+        lines += [
+            f"    NOT supported by the facilitator right now: {', '.join(unsupported)}",
+            "",
+            "    This points at the facilitator, not the docs. Upstream has most likely",
+            "    shipped a protocol or network change that @payai/x402-* has not picked up.",
+            "    Check payai-x402-facilitator before editing these pages.",
+        ]
+    else:
+        lines += [
+            "    All offered networks ARE supported by the facilitator, so the lag theory",
+            "    does not explain this. Treat it as a problem with the documented example.",
+        ]
+    return "\n".join(lines)
+
+
 def main():
     require = "--require" in sys.argv
     missing = [k for k in NEEDED if not os.environ.get(k)]
@@ -119,14 +166,14 @@ def main():
         # appears even on a 402.
         if r.returncode != 0:
             raise RuntimeError("client exited non-zero")
-        if "payment_required" in out:
-            raise RuntimeError("server still demanded payment — nothing settled")
         if "insufficient_balance" in out:
             raise RuntimeError("payer wallet is not funded — top up the CI testnet wallets")
-        if "status: 402" in out:
-            raise RuntimeError("client received a 402 — payment did not complete")
+        if "payment_required" in out or "status: 402" in out:
+            raise RuntimeError("server still demanded payment — nothing settled\n"
+                               + diagnose_failure(out))
         if "status: 200" not in out:
-            raise RuntimeError("client never saw a 200 — the paid resource was not served")
+            raise RuntimeError("client never saw a 200 — the paid resource was not served\n"
+                               + diagnose_failure(out))
 
         print("\n✓ live payment settled: the documented client paid the documented server "
               "through the PayAI facilitator and received the protected resource.")


### PR DESCRIPTION
Three changes, all downstream of measuring when upstream actually ships.

## 1 + 2. Both weekly crons move to Tuesday morning UTC

I checked the claim rather than assuming it:

| registry | Friday | Monday | weekends |
|---|---|---|---|
| npm `@x402/*` | **80 / 162 (49%)** | 40 (25%) | 0 |
| PyPI `x402` | **11 / 20 (55%)** | 4 (20%) | 0 |

Friday dominates, Monday is a real second. Together they're **74% of releases**.

A Tuesday run sits downstream of both clusters. Saturday would catch Friday a day sooner but leave Monday releases waiting most of a week.

- `check-examples.yml`: Mon 06:00 → **Tue 06:00 UTC**
- `sync-upstream.yml`: Mon 07:00 → **Tue 07:00 UTC**

**Why the compile check matters more than the sync here.** The examples themselves change only a few times a year — `clients/fetch` hasn't moved since 2026-06-05 while `@x402/fetch` has published six times since. But our install commands pin nothing; they resolve whatever `@x402/*` is current. So **a release can break the documented code with no docs change at all**, and the compile check is the only thing that catches it.

## 3. The live-payment failure now names the right repo

A failed payment has two very different causes, and the client output doesn't distinguish them:

- our documented example is wrong, or
- upstream shipped a protocol change the PayAI facilitator hasn't absorbed yet

**The second is real, not hypothetical.** The facilitator doesn't depend on upstream `@x402/*` at all — it runs PayAI's own line:

```
apps/api:  @payai/x402: 2.4.4   @payai/x402-evm: 2.4.5
           @payai/x402-svm: 2.4.5   @payai/x402-extensions: 2.4.4
```

That's **2.4.x against upstream's 2.21.0**, last bumped 2026-07-19, with upstream having shipped 2.19, 2.20 and 2.21 since. Separate release lines, so a lag is structurally possible.

On failure the check now queries `facilitator.payai.network/supported` and compares it against the networks the example offered:

```
    example offered: eip155:999999
    NOT supported by the facilitator right now: eip155:999999

    This points at the facilitator, not the docs. Upstream has most likely
    shipped a protocol or network change that @payai/x402-* has not picked up.
    Check payai-x402-facilitator before editing these pages.
```

and the inverse:

```
    example offered: eip155:84532
    All offered networks ARE supported by the facilitator, so the lag theory
    does not explain this. Treat it as a problem with the documented example.
```

Both branches unit-tested against the live `/supported` response.

## Verification

| check | result |
|---|---|
| all four workflows parse, crons correct | ✓ |
| diagnoser, supported-network branch | ✓ |
| diagnoser, unsupported-network branch | ✓ |
| skip path exit 0 / `--require` exit 1 | ✓ |
| delta, links, sync gates unaffected | ✓ |

## Worth noting

Current state is compatible despite the version gap — the live gate passed today with `@x402/*` **2.21.0** talking to a facilitator on `@payai/x402-*` **2.4.5**. The wire protocol is what matters, not matched version numbers. This change is about making the *next* failure legible, not fixing a present one.