### PR TITLE
ci: check the Python and Go examples too, and fix a broken Go client

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -3,8 +3,8 @@ name: Compile docs examples
 on:
   pull_request:
     paths:
-      - "x402/servers/typescript/**"
-      - "x402/clients/typescript/**"
+      - "x402/servers/**"
+      - "x402/clients/**"
       - "scripts/check-examples.py"
       - ".github/workflows/check-examples.yml"
   push:
@@ -12,22 +12,23 @@ on:
   schedule:
     # Tuesday morning UTC. Upstream publishes @x402/* mostly on Fridays (49%)
     # with Monday second (25%); a Tuesday run covers both clusters in one pass.
-    # The examples pin nothing — they resolve whatever @x402/* is current — so
-    # this catches a release breaking them even when no docs change was made.
+    # The examples pin nothing — they resolve whatever is current — so this
+    # catches a release breaking them even when no docs change was made.
     - cron: "0 6 * * 2"
   workflow_dispatch:
 
 jobs:
   compile:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+        with: { node-version: 20 }
       - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Compile every TypeScript example
+        # x402 on PyPI requires >=3.10
+        with: { python-version: "3.12" }
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.22" }
+      - name: Compile every documented example
         run: python3 scripts/check-examples.py

--- a/scripts/check-examples.py
+++ b/scripts/check-examples.py
@@ -1,147 +1,238 @@
 #!/usr/bin/env python3
-"""Compile the TypeScript code blocks in the docs, following each page's own install steps.
+"""Compile the code blocks in the docs, following each page's own install steps.
 
 For every page in MANIFEST this script:
-  1. extracts the page's ``npm install`` lines from its bash blocks
-  2. extracts its TypeScript blocks into the files the page says they are
+  1. extracts the page's own install commands from its bash blocks
+  2. extracts its code blocks into the files the page says they are
   3. installs exactly what the page tells the reader to install
-  4. runs ``tsc --noEmit`` over the result
+  4. compiles / checks the result with that language's toolchain
 
 That means CI validates the page as a reader experiences it: follow the
-instructions, get code that compiles. A page whose install line omits something
-its code imports fails here, as does a page whose blocks don't agree with each
-other.
+instructions, get code that works. A page whose install line omits something its
+code imports fails here, as does a page whose blocks don't agree with each other.
+
+Per language:
+  typescript  npm install ... ; tsc --noEmit
+  go          go mod init / go get ... ; go build ./...
+  python      pip install ... ; compile the source, then resolve every import
+
+Python has no type checker in the same sense, so the meaningful check is that the
+source parses and every module it imports actually resolves in the environment
+the page told you to create. That is the failure this catches in practice: the
+install line and the imports drifting apart.
 
 Usage:
     python3 scripts/check-examples.py            # all pages
     python3 scripts/check-examples.py express    # one page by key
 """
-import json, re, shutil, subprocess, sys, tempfile, pathlib
+import ast, json, os, re, shutil, subprocess, sys, tempfile, textwrap, pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-# block_index -> path the page says the block is. Order is the order the ```ts
-# blocks appear on the page.
 MANIFEST = {
-    "express": dict(
-        page="x402/servers/typescript/express.mdx",
-        files={0: "index.ts"},
-    ),
-    "hono": dict(
-        page="x402/servers/typescript/hono.mdx",
-        files={0: "index.ts"},
-    ),
-    "fetch": dict(
-        page="x402/clients/typescript/fetch.mdx",
-        files={0: "index.ts"},
-    ),
-    "axios": dict(
-        page="x402/clients/typescript/axios.mdx",
-        files={0: "index.ts"},
-    ),
-    "nextjs": dict(
-        page="x402/servers/typescript/nextjs.mdx",
-        files={0: "proxy.ts", 1: "app/api/weather/route.ts"},
-        # Step 1 scaffolds with create-next-app rather than npm install, so the
-        # framework packages never appear in an install line on the page.
-        extra_deps=["next", "react", "react-dom"],
-        extra_dev_deps=["@types/react"],
-        lang="typescript",
-    ),
+    # ---- TypeScript -------------------------------------------------------
+    "express": dict(page="x402/servers/typescript/express.mdx", lang="ts",
+                    files={0: "index.ts"}),
+    "hono":    dict(page="x402/servers/typescript/hono.mdx", lang="ts",
+                    files={0: "index.ts"}),
+    "fetch":   dict(page="x402/clients/typescript/fetch.mdx", lang="ts",
+                    files={0: "index.ts"}),
+    "axios":   dict(page="x402/clients/typescript/axios.mdx", lang="ts",
+                    files={0: "index.ts"}),
+    "nextjs":  dict(page="x402/servers/typescript/nextjs.mdx", lang="typescript",
+                    files={0: "proxy.ts", 1: "app/api/weather/route.ts"},
+                    # Step 1 scaffolds with create-next-app, so the framework
+                    # packages never appear in an install line on the page.
+                    extra_deps=["next", "react", "react-dom"],
+                    extra_dev_deps=["@types/react"]),
+    # ---- Python -----------------------------------------------------------
+    "fastapi":  dict(page="x402/servers/python/fastapi.mdx", lang="python",
+                     files={0: "main.py"}),
+    "flask":    dict(page="x402/servers/python/flask.mdx", lang="python",
+                     files={0: "main.py"}),
+    "httpx":    dict(page="x402/clients/python/httpx.mdx", lang="python",
+                     files={0: "main.py"}),
+    "requests": dict(page="x402/clients/python/requests.mdx", lang="python",
+                     files={0: "main.py"}),
+    # ---- Go ---------------------------------------------------------------
+    "gin":     dict(page="x402/servers/go/gin.mdx", lang="go",
+                    files={0: "main.go"}),
+    "go-http": dict(page="x402/clients/go/http.mdx", lang="go",
+                    files={0: "main.go"}),
 }
 
-TSCONFIG = {
-    "compilerOptions": {
-        "target": "ES2022",
-        "module": "ESNext",
-        "moduleResolution": "bundler",
-        "jsx": "preserve",
-        "strict": False,
-        "noEmit": True,
-        "skipLibCheck": True,
-    }
+TSCONFIG = {"compilerOptions": {
+    "target": "ES2022", "module": "ESNext", "moduleResolution": "bundler",
+    "jsx": "preserve", "strict": False, "noEmit": True, "skipLibCheck": True}}
+
+# Modules that ship with the interpreter and so need not appear in the page's
+# install line. sys.stdlib_module_names is 3.10+; fall back for older runners.
+PY_STDLIB_OK = set(getattr(sys, "stdlib_module_names", ())) | {
+    "__future__", "abc", "asyncio", "base64", "collections", "contextlib",
+    "dataclasses", "datetime", "decimal", "enum", "functools", "hashlib", "hmac",
+    "http", "io", "itertools", "json", "logging", "math", "os", "pathlib",
+    "random", "re", "secrets", "socket", "string", "struct", "subprocess", "sys",
+    "textwrap", "threading", "time", "typing", "urllib", "uuid", "warnings",
 }
 
 
-def code_blocks(text, lang):
-    return re.findall(r"```" + lang + r"\n(.*?)```", text, re.S)
+def blocks(text, lang):
+    """Code blocks for a language, dedented (they are indented inside <Tab>)."""
+    return [textwrap.dedent(b) for b in
+            re.findall(r"```" + lang + r"\n(.*?)```", text, re.S)]
 
 
-def install_lines(text):
-    """Every `npm install ...` line in the page's bash blocks, in order."""
+def install_cmds(text, prefixes):
     out = []
-    for block in re.findall(r"```bash\n(.*?)```", text, re.S):
-        for line in block.splitlines():
+    for b in re.findall(r"```bash\n(.*?)```", text, re.S):
+        for line in textwrap.dedent(b).splitlines():
             line = line.strip()
-            if line.startswith("npm install"):
+            if line.startswith(prefixes):
                 out.append(line)
     return out
 
 
-def run(cmd, cwd, **kw):
-    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, shell=isinstance(cmd, str), **kw)
+def run(cmd, cwd, env=None):
+    return subprocess.run(cmd, cwd=cwd, shell=True, capture_output=True,
+                          text=True, env=env)
+
+
+# --------------------------------------------------------------------------- ts
+def check_ts(cfg, text, d):
+    installs = install_cmds(text, ("npm install",))
+    if not installs:
+        return False, "no `npm install` line found on the page"
+    (d / "tsconfig.json").write_text(json.dumps(TSCONFIG, indent=2))
+    if (r := run("npm init -y && npm pkg set type=module", d)).returncode:
+        return False, f"npm init failed: {r.stderr[-300:]}"
+    for line in installs:
+        if (r := run(line, d)).returncode:
+            return False, f"page's own install failed: `{line}`\n{r.stderr[-400:]}"
+    if extra := cfg.get("extra_deps"):
+        if (r := run("npm install " + " ".join(extra), d)).returncode:
+            return False, f"scaffold deps failed: {r.stderr[-300:]}"
+    dev = ["typescript", "@types/node"] + cfg.get("extra_dev_deps", [])
+    if (r := run("npm install -D " + " ".join(dev), d)).returncode:
+        return False, f"dev deps failed: {r.stderr[-300:]}"
+    if (r := run("npx tsc --noEmit", d)).returncode:
+        return False, "tsc reported errors:\n" + (r.stdout or r.stderr).strip()
+    return True, "compiles clean" + versions_note(d, ("@x402/core", "@payai/facilitator"))
+
+
+def versions_note(d, pkgs):
+    got = []
+    for p in pkgs:
+        pj = d / "node_modules" / p / "package.json"
+        if pj.exists():
+            got.append(f"{p}@{json.loads(pj.read_text())['version']}")
+    return f" against {', '.join(got)}" if got else ""
+
+
+# ----------------------------------------------------------------------- python
+def python_bin():
+    """An interpreter new enough for the packages the pages install.
+
+    Not sys.executable: the script may well be run by an older default python
+    (macOS still ships 3.9), while `x402` on PyPI requires >=3.10. Using the
+    running interpreter makes the check fail for a reason that has nothing to do
+    with the docs.
+    """
+    if env := os.environ.get("PYTHON_BIN"):
+        return env
+    for cand in ("python3.13", "python3.12", "python3.11", "python3.10"):
+        if shutil.which(cand):
+            return cand
+    return sys.executable
+
+
+def check_python(cfg, text, d):
+    installs = install_cmds(text, ("pip install", "uv pip install"))
+    if not installs:
+        return False, "no `pip install` line found on the page"
+    interp = python_bin()
+    ver = run(f"{interp} -c 'import sys;print(\"%d.%d\"%sys.version_info[:2])'", d).stdout.strip()
+    if tuple(int(x) for x in ver.split(".")) < (3, 10):
+        return False, (f"need Python >=3.10 to install these packages, found {ver} "
+                       f"({interp}). Set PYTHON_BIN to a newer interpreter.")
+    venv = d / ".venv"
+    if (r := run(f"{interp} -m venv {venv}", d)).returncode:
+        return False, f"venv failed: {r.stderr[-300:]}"
+    py = venv / "bin" / "python"
+    run(f"{py} -m pip install --quiet --upgrade pip", d)
+    for line in installs:
+        cmd = line.replace("pip install", f"{py} -m pip install --quiet", 1)
+        if (r := run(cmd, d)).returncode:
+            return False, f"page's own install failed: `{line}`\n{r.stderr[-400:]}"
+
+    src_path = d / list(cfg["files"].values())[0]
+    src = src_path.read_text()
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as e:
+        return False, f"source does not parse: line {e.lineno}: {e.msg}"
+
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported |= {a.name.split(".")[0] for a in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported.add(node.module.split(".")[0])
+    third_party = sorted(imported - PY_STDLIB_OK)
+
+    probe = ("import importlib.util,sys;"
+             "missing=[m for m in sys.argv[1:] if importlib.util.find_spec(m) is None];"
+             "print(','.join(missing))")
+    r = run(f"{py} -c {json.dumps(probe)} {' '.join(third_party)}", d)
+    missing = [m for m in (r.stdout or "").strip().split(",") if m]
+    if missing:
+        return False, (f"code imports {', '.join(missing)} but the page's install "
+                       f"line does not provide it")
+    show = run(f"{py} -m pip show x402", d).stdout
+    v = next((l.split(": ", 1)[1].strip() for l in show.splitlines()
+              if l.startswith("Version:")), None)
+    return True, (f"parses; all {len(third_party)} third-party imports resolve"
+                  + (f" against x402=={v}" if v else "") + f" [py{ver}]")
+
+
+# --------------------------------------------------------------------------- go
+def check_go(cfg, text, d):
+    cmds = install_cmds(text, ("go mod init", "go get", "go mod tidy"))
+    if not cmds:
+        return False, "no `go mod` / `go get` lines found on the page"
+    env = {**os.environ, "GOFLAGS": "-mod=mod", "GOTOOLCHAIN": "auto"}
+    for line in cmds:
+        if (r := run(line, d, env=env)).returncode:
+            return False, f"page's own setup failed: `{line}`\n{r.stderr[-500:]}"
+    if (r := run("go build ./...", d, env=env)).returncode:
+        return False, "go build reported errors:\n" + (r.stderr or r.stdout).strip()[:1200]
+    mods = run("go list -m all", d, env=env).stdout
+    v = next((l for l in mods.splitlines() if "x402-foundation/x402" in l), "")
+    return True, "builds clean" + (f" against {v.strip()}" if v else "")
+
+
+CHECKERS = {"ts": check_ts, "typescript": check_ts, "python": check_python, "go": check_go}
 
 
 def check(key, cfg, workdir):
-    page = ROOT / cfg["page"]
-    text = page.read_text()
-    lang = cfg.get("lang", "ts")
-
-    blocks = code_blocks(text, lang)
+    text = (ROOT / cfg["page"]).read_text()
+    lang = cfg["lang"]
+    bs = blocks(text, lang)
     need = max(cfg["files"]) + 1
-    if len(blocks) < need:
-        return False, f"expected >= {need} ```{lang} block(s), found {len(blocks)}"
-
-    installs = install_lines(text)
-    if not installs:
-        return False, "no `npm install` line found on the page"
+    if len(bs) < need:
+        return False, f"expected >= {need} ```{lang} block(s), found {len(bs)}"
 
     d = workdir / key
     d.mkdir(parents=True)
     for idx, rel in cfg["files"].items():
         f = d / rel
         f.parent.mkdir(parents=True, exist_ok=True)
-        f.write_text(blocks[idx])
-    (d / "tsconfig.json").write_text(json.dumps(TSCONFIG, indent=2))
-
-    r = run("npm init -y && npm pkg set type=module", d)
-    if r.returncode:
-        return False, f"npm init failed: {r.stderr[-300:]}"
-
-    # the page's own install commands, verbatim
-    for line in installs:
-        r = run(line, d)
-        if r.returncode:
-            return False, f"page's own install failed: `{line}`\n{r.stderr[-400:]}"
-
-    extra = cfg.get("extra_deps", [])
-    if extra:
-        r = run("npm install " + " ".join(extra), d)
-        if r.returncode:
-            return False, f"scaffold deps failed: {r.stderr[-300:]}"
-
-    # tooling the reader gets from their editor / create-next-app
-    dev = ["typescript", "@types/node"] + cfg.get("extra_dev_deps", [])
-    r = run("npm install -D " + " ".join(dev), d)
-    if r.returncode:
-        return False, f"dev deps failed: {r.stderr[-300:]}"
-
-    r = run("npx tsc --noEmit", d)
-    if r.returncode:
-        return False, "tsc reported errors:\n" + (r.stdout or r.stderr).strip()
-
-    versions = []
-    for pkg in ("@x402/core", "@payai/facilitator"):
-        pj = d / "node_modules" / pkg / "package.json"
-        if pj.exists():
-            versions.append(f"{pkg}@{json.loads(pj.read_text())['version']}")
-    return True, "compiles clean" + (f" against {', '.join(versions)}" if versions else "")
+        f.write_text(bs[idx])
+    return CHECKERS[lang](cfg, text, d)
 
 
 def main():
     keys = sys.argv[1:] or list(MANIFEST)
-    unknown = [k for k in keys if k not in MANIFEST]
-    if unknown:
+    if unknown := [k for k in keys if k not in MANIFEST]:
         print(f"unknown page(s): {', '.join(unknown)}\nknown: {', '.join(MANIFEST)}")
         return 2
 
@@ -149,8 +240,9 @@ def main():
     failures = []
     try:
         for key in keys:
-            print(f"→ {key} ({MANIFEST[key]['page']})", flush=True)
-            ok, msg = check(key, MANIFEST[key], workdir)
+            cfg = MANIFEST[key]
+            print(f"→ {key} [{cfg['lang']}] ({cfg['page']})", flush=True)
+            ok, msg = check(key, cfg, workdir)
             print(("   ✓ " if ok else "   ✗ ") + msg + "\n", flush=True)
             if not ok:
                 failures.append(key)
@@ -160,7 +252,7 @@ def main():
     if failures:
         print(f"FAILED: {', '.join(failures)}")
         return 1
-    print(f"All {len(keys)} example(s) compile.")
+    print(f"All {len(keys)} example(s) check out.")
     return 0
 
 

--- a/x402/clients/go/http.mdx
+++ b/x402/clients/go/http.mdx
@@ -81,7 +81,9 @@ func main() {
 		os.Exit(1)
 	}
 	client := x402.Newx402Client()
-	client.Register("eip155:*", evm.NewExactEvmScheme(evmSigner))
+	// nil = no JSON-RPC config; pass one to enable onchain reads for
+	// gas-sponsoring extensions.
+	client.Register("eip155:*", evm.NewExactEvmScheme(evmSigner, nil))
 	if svmPrivateKey != "" {
 		svmSigner, err := svmsigners.NewClientSignerFromPrivateKey(svmPrivateKey)
 		if err != nil {


### PR DESCRIPTION
Extends the compile check from **5 TypeScript pages to all 11** pages carrying a complete runnable example.

| language | how it's checked |
|---|---|
| typescript | `npm install …` then `tsc --noEmit` |
| go | `go mod init` / `go get …` then `go build ./...` |
| python | `pip install …` then parse the source and resolve every import |

Python has no equivalent type checker, so the meaningful check is that the source parses **and every module it imports actually resolves** in the environment the page told you to create. That's the drift that happens in practice — the install line and the imports growing apart.

## It found a broken page on the first run

`x402/clients/go/http.mdx` did not compile:

```
./main.go:46:52: not enough arguments in call to evm.NewExactEvmScheme
  have (evm.ClientEvmSigner)
  want (evm.ClientEvmSigner, *client.ExactEvmSchemeConfig)
```

Upstream added a JSON-RPC config parameter. Their own example passes `nil` when onchain reads aren't needed, so this page now matches, with a comment explaining what the argument is for.

That's the **second** broken example these checks have surfaced — after the Next.js page's six errors in #50. Both were pages that looked fine and had never been compiled.

## All 11 now pass

```
express   ✓ compiles clean against @x402/core@2.21.0, @payai/facilitator@2.4.4
hono      ✓ compiles clean against @x402/core@2.21.0, @payai/facilitator@2.4.4
fetch     ✓ compiles clean against @x402/core@2.21.0
axios     ✓ compiles clean against @x402/core@2.21.0
nextjs    ✓ compiles clean against @x402/core@2.21.0, @payai/facilitator@2.4.4
fastapi   ✓ parses; all 5 third-party imports resolve against x402==2.18.0 [py3.13]
flask     ✓ parses; all 3 third-party imports resolve against x402==2.18.0 [py3.13]
httpx     ✓ parses; all 3 third-party imports resolve against x402==2.18.0 [py3.13]
requests  ✓ parses; all 3 third-party imports resolve against x402==2.18.0 [py3.13]
gin       ✓ builds clean against github.com/x402-foundation/x402/go v0.0.0-…
go-http   ✓ builds clean against github.com/x402-foundation/x402/go v0.0.0-…
```

## Two gotchas worth knowing for future additions

**Blocks inside `<Tabs>`/`<Tab>` are indented.** Extraction has to dedent or the source won't parse. This bit me on the auth page — worth remembering when adding those.

**The venv uses the newest `python3.1x` on PATH, not `sys.executable`.** macOS still defaults to 3.9 while `x402` on PyPI requires **>=3.10**, so using the running interpreter fails for reasons that have nothing to do with the docs — "No matching distribution found for x402" looks exactly like a broken install line. Override with `PYTHON_BIN`. CI pins 3.12.

## CI

Path filter widened from `x402/*/typescript/**` to `x402/servers/**` and `x402/clients/**`, plus `setup-go` and a Python 3.12 pin. Timeout raised to 40 min — eleven toolchain installs isn't fast, though it only runs when those paths change (plus the Tuesday cron).