### PR TITLE
ci: sync the Python and Go examples from upstream too

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -6,6 +6,10 @@ on:
       - "x402/servers/**"
       - "x402/clients/**"
       - "scripts/check-examples.py"
+      # patches/ decides what a sync writes into the pages, so a change here can
+      # break an example just as surely as editing the page directly.
+      - "patches/**"
+      - "scripts/sync_upstream.py"
       - ".github/workflows/check-examples.yml"
   push:
     branches: [main]

--- a/patches/README.md
+++ b/patches/README.md
@@ -17,6 +17,32 @@ buyer talks to no facilitator.
 | `hono.patch` | `x402/servers/typescript/hono.mdx` | facilitator swap + bazaar discovery |
 | `fetch.patch` | `x402/clients/typescript/fetch.mdx` | *(empty — pure mirror)* |
 | `axios.patch` | `x402/clients/typescript/axios.mdx` | *(empty — pure mirror)* |
+| `fastapi.patch` | `x402/servers/python/fastapi.mdx` | small prose/wiring edits |
+| `flask.patch` | `x402/servers/python/flask.mdx` | *(empty — pure mirror)* |
+| `httpx.patch` | `x402/clients/python/httpx.mdx` | condensed from upstream |
+| `requests.patch` | `x402/clients/python/requests.mdx` | condensed from upstream |
+| `gin.patch` | `x402/servers/go/gin.mdx` | condensed from upstream |
+
+**Python and Go carry the delta differently.** There is no `@payai/*` package to
+import, so the PayAI-ness lives in the page's `.env` block as
+`FACILITATOR_URL=https://facilitator.payai.network` rather than in the code. That
+is why `flask.patch` is empty despite the page being PayAI-specific — and why
+`check_deltas.py` scopes those rules to the whole page instead of the code block.
+
+It also means the failure mode is quiet: the upstream `fastapi` and `flask` code
+falls back to `https://x402.org/facilitator` when `FACILITATOR_URL` is unset, so
+losing that env line points readers at someone else's facilitator without
+anything breaking.
+
+## Deliberately not synced
+
+| page | why |
+|---|---|
+| `x402/clients/go/http.mdx` | upstream splits this across `main.go`, `builder_pattern.go` and `utils.go`; our page condenses it into one block. The diff is **151%** of the page, so it is an adaptation, not a mirror. |
+| `x402/servers/typescript/nextjs.mdx` | two code blocks from two upstream files; the sync assumes one block per page. |
+
+Both are still covered by `check-examples.py`, so they cannot silently stop
+compiling — they just are not auto-updated.
 
 ## If you hand-edit an example
 

--- a/patches/fastapi.patch
+++ b/patches/fastapi.patch
@@ -1,0 +1,35 @@
+--- a/fastapi.py
++++ b/fastapi.py
+@@ -5,7 +5,7 @@
+ from pydantic import BaseModel
+ 
+ from x402.http import FacilitatorConfig, HTTPFacilitatorClient, PaymentOption
+-from x402.http.middleware.fastapi import PaymentMiddlewareASGI, payment_middleware  # noqa: F401
++from x402.http.middleware.fastapi import PaymentMiddlewareASGI
+ from x402.http.types import RouteConfig
+ from x402.mechanisms.evm.exact import ExactEvmServerScheme
+ from x402.mechanisms.svm.exact import ExactSvmServerScheme
+@@ -50,7 +50,6 @@
+ server.register(SVM_NETWORK, ExactSvmServerScheme())
+ 
+ routes = {
+-    # a first way to pay for the weather report, it's a string
+     "GET /weather": RouteConfig(
+         accepts=[
+             PaymentOption(
+@@ -69,7 +68,6 @@
+         mime_type="application/json",
+         description="Weather report",
+     ),
+-    # a second way to pay for the premium content, it's an AssetAmount object
+     "GET /premium/*": RouteConfig(
+         accepts=[
+             PaymentOption(
+@@ -94,7 +92,6 @@
+     ),
+ }
+ app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
+-# app.middleware("http")(payment_middleware(routes=routes, server=server))  # Alternative way to register the middleware
+ 
+ 
+ # Routes

--- a/patches/gin.patch
+++ b/patches/gin.patch
@@ -1,0 +1,30 @@
+--- a/gin.go
++++ b/gin.go
+@@ -6,13 +6,13 @@
+ 	"os"
+ 	"time"
+ 
++	x402 "github.com/x402-foundation/x402/go"
++	x402http "github.com/x402-foundation/x402/go/http"
++	ginmw "github.com/x402-foundation/x402/go/http/gin"
++	evm "github.com/x402-foundation/x402/go/mechanisms/evm/exact/server"
++	svm "github.com/x402-foundation/x402/go/mechanisms/svm/exact/server"
+ 	ginfw "github.com/gin-gonic/gin"
+ 	"github.com/joho/godotenv"
+-	x402 "github.com/x402-foundation/x402/go/v2"
+-	x402http "github.com/x402-foundation/x402/go/v2/http"
+-	ginmw "github.com/x402-foundation/x402/go/v2/http/gin"
+-	evm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/exact/server"
+-	svm "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/server"
+ )
+ 
+ const (
+@@ -96,7 +96,7 @@
+ 			ginmw.SchemeConfig{Network: "eip155:84532", Server: evm.NewExactEvmScheme()},
+ 			ginmw.SchemeConfig{Network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", Server: svm.NewExactSvmScheme()},
+ 		},
+-		Timeout: 30 * time.Second,
++		Timeout:    30 * time.Second,
+ 	}))
+ 
+ 	/**

--- a/patches/httpx.patch
+++ b/patches/httpx.patch
@@ -1,0 +1,28 @@
+--- a/httpx.py
++++ b/httpx.py
+@@ -85,13 +85,18 @@
+         print(f"Response body: {response.text}")
+ 
+         # Extract and print payment response if present
+-        try:
+-            settle_response = http_client.get_payment_settle_response(
+-                lambda name: response.headers.get(name)
+-            )
+-            print(f"\nPayment response: {settle_response.model_dump_json(indent=2)}")
+-        except ValueError:
+-            print("\nNo payment response header found")
++        if response.is_success:
++            try:
++                settle_response = http_client.get_payment_settle_response(
++                    lambda name: response.headers.get(name)
++                )
++                print(
++                    f"\nPayment response: {settle_response.model_dump_json(indent=2)}"
++                )
++            except ValueError:
++                print("\nNo payment response header found")
++        else:
++            print(f"\nRequest failed (status: {response.status_code})")
+ 
+ 
+ if __name__ == "__main__":

--- a/patches/requests.patch
+++ b/patches/requests.patch
@@ -1,0 +1,28 @@
+--- a/requests.py
++++ b/requests.py
+@@ -83,13 +83,18 @@
+         print(f"Response body: {response.text}")
+ 
+         # Extract and print payment response if present
+-        try:
+-            settle_response = http_client.get_payment_settle_response(
+-                lambda name: response.headers.get(name)
+-            )
+-            print(f"\nPayment response: {settle_response.model_dump_json(indent=2)}")
+-        except ValueError:
+-            print("\nNo payment response header found")
++        if response.ok:
++            try:
++                settle_response = http_client.get_payment_settle_response(
++                    lambda name: response.headers.get(name)
++                )
++                print(
++                    f"\nPayment response: {settle_response.model_dump_json(indent=2)}"
++                )
++            except ValueError:
++                print("\nNo payment response header found")
++        else:
++            print(f"\nRequest failed (status: {response.status_code})")
+ 
+ 
+ if __name__ == "__main__":

--- a/scripts/check_deltas.py
+++ b/scripts/check_deltas.py
@@ -49,11 +49,41 @@ RULES = {
         ("can pay on EVM",   '@x402/evm'),
         ("can pay on Solana", '@x402/svm'),
     ]),
+
+    # Python and Go carry the delta differently. There is no @payai/* package to
+    # import, so the PayAI-ness lives in the page's .env block as
+    # FACILITATOR_URL. Scope "page" checks the whole file, not just code blocks.
+    # This matters: the upstream fastapi/flask code falls back to
+    # https://x402.org/facilitator when FACILITATOR_URL is unset, so if that env
+    # line ever goes missing the example silently uses someone else's facilitator.
+    "fastapi": ("x402/servers/python/fastapi.mdx", "python", [
+        ("points at the PayAI facilitator", 'FACILITATOR_URL=https://facilitator.payai.network'),
+    ], "page"),
+    "flask": ("x402/servers/python/flask.mdx", "python", [
+        ("points at the PayAI facilitator", 'FACILITATOR_URL=https://facilitator.payai.network'),
+    ], "page"),
+    "gin": ("x402/servers/go/gin.mdx", "go", [
+        ("points at the PayAI facilitator", 'FACILITATOR_URL=https://facilitator.payai.network'),
+    ], "page"),
+    "httpx": ("x402/clients/python/httpx.mdx", "python", [
+        ("can pay on EVM",    'evm'),
+        ("can pay on Solana", 'svm'),
+    ]),
+    "requests": ("x402/clients/python/requests.mdx", "python", [
+        ("can pay on EVM",    'evm'),
+        ("can pay on Solana", 'svm'),
+    ]),
+    "go-http": ("x402/clients/go/http.mdx", "go", [
+        ("can pay on EVM",    'evm'),
+        ("can pay on Solana", 'svm'),
+    ]),
 }
 
 
-def page_code(page, lang):
+def haystack(page, lang, scope):
     text = (ROOT / page).read_text()
+    if scope == "page":
+        return text
     blocks = re.findall(r"```" + lang + r"\n(.*?)```", text, re.S)
     return "\n".join(blocks)          # all blocks — nextjs splits across two
 
@@ -67,8 +97,10 @@ def main():
 
     failures = []
     for key in keys:
-        page, lang, rules = RULES[key]
-        code = page_code(page, lang)
+        entry = RULES[key]
+        page, lang, rules = entry[0], entry[1], entry[2]
+        scope = entry[3] if len(entry) > 3 else "code"
+        code = haystack(page, lang, scope)
         missing = [desc for desc, needle in rules if needle not in code]
         if missing:
             failures.append(key)

--- a/scripts/sync_upstream.py
+++ b/scripts/sync_upstream.py
@@ -33,10 +33,21 @@ PAGES = {
                 "examples/typescript/clients/fetch/index.ts", "ts", 0),
     "axios":   ("x402/clients/typescript/axios.mdx",
                 "examples/typescript/clients/axios/index.ts", "ts", 0),
-    # Expansion path — each is data, not code:
-    #   nextjs  (multi-file: proxy.ts + app/api/weather/route.ts)
-    #   fastapi, flask, httpx, requests   (python)
-    #   gin, go-http                       (go)
+    "fastapi":  ("x402/servers/python/fastapi.mdx",
+                 "examples/python/servers/fastapi/main.py", "python", 0),
+    "flask":    ("x402/servers/python/flask.mdx",
+                 "examples/python/servers/flask/main.py", "python", 0),
+    "httpx":    ("x402/clients/python/httpx.mdx",
+                 "examples/python/clients/httpx/main.py", "python", 0),
+    "requests": ("x402/clients/python/requests.mdx",
+                 "examples/python/clients/requests/main.py", "python", 0),
+    "gin":      ("x402/servers/go/gin.mdx",
+                 "examples/go/servers/gin/main.go", "go", 0),
+    # Deliberately NOT synced:
+    #   go-http  upstream splits this across main.go, builder_pattern.go and
+    #            utils.go while our page condenses it into one block. The diff
+    #            is 151% of the page, so it is an adaptation, not a mirror.
+    #   nextjs   two code blocks from two upstream files; the sync assumes one.
 }
 
 
@@ -66,9 +77,12 @@ def page_block(page, lang, index):
     return blocks[index], text, blocks
 
 
-def expected_code(key, up_text, work):
+EXT = {"ts": "ts", "typescript": "ts", "python": "py", "go": "go"}
+
+
+def expected_code(key, up_text, work, lang="ts"):
     """upstream + our patch = what the page should show."""
-    f = work / f"{key}.ts"
+    f = work / f"{key}.{EXT[lang]}"
     f.write_text(up_text)
     patch = ROOT / "patches" / f"{key}.patch"
     if not patch.exists() or not patch.read_text().strip():
@@ -88,7 +102,7 @@ def sync(keys, write):
             page, up_path, lang, idx = PAGES[key]
             up_text = upstream_file(up_path)
             sha = upstream_sha(up_path)
-            expected, err = expected_code(key, up_text, work)
+            expected, err = expected_code(key, up_text, work, lang)
 
             if expected is None:
                 conflicts.append(key)
@@ -149,11 +163,12 @@ def main():
         try:
             for key in keys:
                 page, up_path, lang, idx = PAGES[key]
+                ext = EXT[lang]
                 up = work / f"{key}.up"; up.write_text(upstream_file(up_path))
                 ours = work / f"{key}.ours"
                 ours.write_text(page_block(page, lang, idx)[0])
                 r = subprocess.run(
-                    ["diff", "-u", "--label", f"a/{key}.ts", "--label", f"b/{key}.ts",
+                    ["diff", "-u", "--label", f"a/{key}.{ext}", "--label", f"b/{key}.{ext}",
                      str(up), str(ours)], capture_output=True, text=True)
                 out = ROOT / "patches" / f"{key}.patch"
                 out.write_text(r.stdout)


### PR DESCRIPTION
Extends the upstream sync from **4 pages to 9** — adds fastapi, flask, httpx, requests and gin.

## Which pages, chosen by measurement

Each candidate was diffed against its upstream example rather than assumed to be a mirror:

| page | diff vs upstream | |
|---|---|---|
| flask | **0%** | pure mirror |
| fastapi | 4% | |
| gin | 8% | |
| httpx | 18% | |
| requests | 19% | |
| **go-http** | **151%** | **excluded** |

`go-http` is excluded deliberately: upstream splits it across `main.go`, `builder_pattern.go` and `utils.go` while our page condenses it into one block. It's an adaptation, not a mirror, and a patch would be meaningless. `nextjs` is excluded for the same class of reason — two blocks from two upstream files, where the sync assumes one.

Both stay covered by `check-examples.py`, so they can't silently stop compiling. They just aren't auto-updated.

## Python and Go carry the delta differently

There's no `@payai/*` package to import, so the PayAI-ness lives in the page's `.env` block as `FACILITATOR_URL=https://facilitator.payai.network` rather than in the code. That's why **flask's patch is empty despite the page being PayAI-specific**, and why `check_deltas.py` now scopes those rules to the whole page instead of the code block.

**This matters more than it looks.** The upstream fastapi and flask code falls back to `https://x402.org/facilitator` when `FACILITATOR_URL` is unset:

```python
FACILITATOR_URL = os.getenv("FACILITATOR_URL", "https://x402.org/facilitator")
```

So losing that one env line would quietly point readers at someone else's facilitator with nothing appearing to break — no error, no failed build, payments just going through a testnet-only facilitator that isn't ours. `check_deltas` now fails on exactly that. Verified by swapping the URL to x402.org and watching it catch:

```
✗ fastapi (x402/servers/python/fastapi.mdx)
    no longer points at the PayAI facilitator
DELTA LOST: fastapi
```

## Verified per language, not just in aggregate

| check | result |
|---|---|
| all 9 pages in sync today | ✓ |
| drift detected — Python (fastapi) | ✓ exit 1, readable diff |
| drift detected — Go (gin) | ✓ exit 1, readable diff |
| `--write` restores both byte-identical | ✓ |
| patch conflict — Python (httpx) | ✓ exit 2, "needs a human" |
| delta check catches a stripped `FACILITATOR_URL` | ✓ exit 1 |
| all 11 delta assertions hold | ✓ |
| links clean | ✓ |

One note on my own testing: my first two drift tests silently passed because the strings I injected didn't exist on those pages (`grep -c` → 0). A no-op edit produces no drift, which looks identical to a broken detector. Re-ran against lines confirmed present before trusting the result.

## Also generalised

`sync_upstream.py` hardcoded `.ts` in the temp filename, which `git apply` matches against the patch header — so patches for `.py` and `.go` would never have applied. Now language-aware, in both `--check`/`--write` and `--regen`.