### PR TITLE
docs: production auth for the Python and Go servers, verified live

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -43,3 +43,25 @@ jobs:
         # failure rather than a silent skip. Without this the gate can quietly
         # stop testing anything the moment a secret is renamed or removed.
         run: python3 scripts/check_live_payment.py --require
+
+  auth:
+    name: Authenticated settlement (PayAI JWT)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    environment: docs-live-payment
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - name: Boot the documented FastAPI server with the PayAI auth provider
+        env:
+          PAYAI_API_KEY_ID: ${{ secrets.PAYAI_API_KEY_ID }}
+          PAYAI_API_KEY_SECRET: ${{ secrets.PAYAI_API_KEY_SECRET }}
+          EVM_PRIVATE_KEY: ${{ secrets.TESTNET_EVM_PRIVATE_KEY }}
+          SVM_PRIVATE_KEY: ${{ secrets.TESTNET_SVM_PRIVATE_KEY }}
+          EVM_ADDRESS: ${{ secrets.TESTNET_EVM_ADDRESS }}
+          SVM_ADDRESS: ${{ secrets.TESTNET_SVM_ADDRESS }}
+        run: python3 scripts/check_auth_live.py --require

--- a/scripts/check-examples.py
+++ b/scripts/check-examples.py
@@ -46,17 +46,19 @@ MANIFEST = {
                     extra_deps=["next", "react", "react-dom"],
                     extra_dev_deps=["@types/react"]),
     # ---- Python -----------------------------------------------------------
+    # block 1 is the PayAI auth provider from the production section; block 2 is
+    # a usage fragment, not a standalone file, so it is not compiled.
     "fastapi":  dict(page="x402/servers/python/fastapi.mdx", lang="python",
-                     files={0: "main.py"}),
+                     files={0: "main.py", 1: "payai_auth.py"}),
     "flask":    dict(page="x402/servers/python/flask.mdx", lang="python",
-                     files={0: "main.py"}),
+                     files={0: "main.py", 1: "payai_auth.py"}),
     "httpx":    dict(page="x402/clients/python/httpx.mdx", lang="python",
                      files={0: "main.py"}),
     "requests": dict(page="x402/clients/python/requests.mdx", lang="python",
                      files={0: "main.py"}),
     # ---- Go ---------------------------------------------------------------
     "gin":     dict(page="x402/servers/go/gin.mdx", lang="go",
-                    files={0: "main.go"}),
+                    files={0: "main.go", 1: "payaiauth/provider.go"}),
     "go-http": dict(page="x402/clients/go/http.mdx", lang="go",
                     files={0: "main.go"}),
 }
@@ -164,20 +166,20 @@ def check_python(cfg, text, d):
         if (r := run(cmd, d)).returncode:
             return False, f"page's own install failed: `{line}`\n{r.stderr[-400:]}"
 
-    src_path = d / list(cfg["files"].values())[0]
-    src = src_path.read_text()
-    try:
-        tree = ast.parse(src)
-    except SyntaxError as e:
-        return False, f"source does not parse: line {e.lineno}: {e.msg}"
-
     imported = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imported |= {a.name.split(".")[0] for a in node.names}
-        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-            imported.add(node.module.split(".")[0])
-    third_party = sorted(imported - PY_STDLIB_OK)
+    local = {pathlib.Path(f).stem for f in cfg["files"].values()}
+    for rel in cfg["files"].values():
+        src = (d / rel).read_text()
+        try:
+            tree = ast.parse(src)
+        except SyntaxError as e:
+            return False, f"{rel} does not parse: line {e.lineno}: {e.msg}"
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported |= {a.name.split(".")[0] for a in node.names}
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                imported.add(node.module.split(".")[0])
+    third_party = sorted(imported - PY_STDLIB_OK - local)
 
     probe = ("import importlib.util,sys;"
              "missing=[m for m in sys.argv[1:] if importlib.util.find_spec(m) is None];"
@@ -190,7 +192,7 @@ def check_python(cfg, text, d):
     show = run(f"{py} -m pip show x402", d).stdout
     v = next((l.split(": ", 1)[1].strip() for l in show.splitlines()
               if l.startswith("Version:")), None)
-    return True, (f"parses; all {len(third_party)} third-party imports resolve"
+    return True, (f"{len(cfg['files'])} file(s) parse; all {len(third_party)} third-party imports resolve"
                   + (f" against x402=={v}" if v else "") + f" [py{ver}]")
 
 

--- a/scripts/check_auth_live.py
+++ b/scripts/check_auth_live.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Prove the documented PayAI auth provider works against the live facilitator.
+
+Boots the FastAPI server example straight off the docs page, wired to the
+PayAI auth provider from that same page's production section, then pays it with
+the documented Fetch client. If the payment settles, the merchant authenticated
+successfully.
+
+Why it is shaped this way. Probing /verify directly does not work: the
+facilitator validates the request body before the token, so a request with a
+bogus body returns the same 400 whether the Authorization header is absent,
+malformed, or a well-formed unsigned token. And unauthenticated requests succeed
+anyway on the free tier, so "did not 401" proves nothing. A settled payment
+through a server configured with the provider is the signal that actually means
+the token was accepted.
+
+Requires, in addition to the live-payment wallets:
+
+    PAYAI_API_KEY_ID       merchant API key id
+    PAYAI_API_KEY_SECRET   Ed25519 PKCS#8 secret, payai_sk_ prefix optional
+
+Skips with exit 0 when they are absent. Pass --require to make absence fatal.
+"""
+import os, pathlib, re, shutil, signal, subprocess, sys, tempfile, textwrap, time
+import urllib.error, urllib.request
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PORT = int(os.environ.get("DOCS_AUTH_PORT", "4131"))
+
+SERVER_PAGE = "x402/servers/python/fastapi.mdx"
+CLIENT_PAGE = "x402/clients/typescript/fetch.mdx"
+NEEDED = ("PAYAI_API_KEY_ID", "PAYAI_API_KEY_SECRET",
+          "EVM_PRIVATE_KEY", "SVM_PRIVATE_KEY", "EVM_ADDRESS", "SVM_ADDRESS")
+
+
+def blocks(page, lang):
+    text = (ROOT / page).read_text()
+    return [textwrap.dedent(b) for b in
+            re.findall(r"```" + lang + r"\n(.*?)```", text, re.S)]
+
+
+def install_lines(page, prefix):
+    out = []
+    for b in re.findall(r"```bash\n(.*?)```", (ROOT / page).read_text(), re.S):
+        out += [l.strip() for l in textwrap.dedent(b).splitlines()
+                if l.strip().startswith(prefix)]
+    return out
+
+
+def sh(cmd, cwd, env=None):
+    return subprocess.run(cmd, cwd=cwd, shell=True, capture_output=True,
+                          text=True, env=env)
+
+
+def python_bin():
+    for c in ("python3.13", "python3.12", "python3.11", "python3.10"):
+        if shutil.which(c):
+            return c
+    return sys.executable
+
+
+def wire_auth(main_src):
+    """Apply the page's own production wiring: pass auth_provider to the client.
+
+    The docs show this as a snippet rather than a second copy of main.py, so the
+    substitution here mirrors exactly what a reader is told to change.
+    """
+    pattern = re.compile(
+        r"facilitator\s*=\s*HTTPFacilitatorClient\(\s*FacilitatorConfig\(url=FACILITATOR_URL\)\s*\)")
+    replacement = (
+        "from payai_auth import PayAIAuthProvider\n"
+        "facilitator = HTTPFacilitatorClient(\n"
+        "    FacilitatorConfig(\n"
+        "        url=FACILITATOR_URL,\n"
+        "        auth_provider=PayAIAuthProvider(\n"
+        '            os.environ["PAYAI_API_KEY_ID"],\n'
+        '            os.environ["PAYAI_API_KEY_SECRET"],\n'
+        "        ),\n"
+        "    )\n"
+        ")")
+    new, n = pattern.subn(replacement, main_src, count=1)
+    if n != 1:
+        raise RuntimeError(
+            "could not find the facilitator client construction in the FastAPI "
+            "example — the page changed shape and this gate needs updating")
+    return new
+
+
+def main():
+    require = "--require" in sys.argv
+    missing = [k for k in NEEDED if not os.environ.get(k)]
+    if missing:
+        msg = f"auth check skipped — missing {', '.join(missing)}"
+        print(("ERROR: " if require else "SKIP: ") + msg)
+        return 1 if require else 0
+
+    work = pathlib.Path(tempfile.mkdtemp(prefix="auth-live-"))
+    proc = None
+    try:
+        # ---- server: the documented FastAPI example, with auth wired in
+        srv = work / "server"; srv.mkdir(parents=True)
+        py_blocks = blocks(SERVER_PAGE, "python")
+        (srv / "payai_auth.py").write_text(py_blocks[1])
+        (srv / "main.py").write_text(wire_auth(py_blocks[0]))
+        print(f"→ built server from {SERVER_PAGE} with the auth provider wired")
+
+        interp = python_bin()
+        sh(f"{interp} -m venv .venv", srv)
+        vpy = srv / ".venv" / "bin" / "python"
+        sh(f"{vpy} -m pip install --quiet --upgrade pip", srv)
+        for line in install_lines(SERVER_PAGE, "pip install"):
+            r = sh(line.replace("pip install", f"{vpy} -m pip install --quiet", 1), srv)
+            if r.returncode:
+                raise RuntimeError(f"server install failed: {line}\n{r.stderr[-300:]}")
+
+        # ---- client: the documented Fetch example
+        cli = work / "client"; cli.mkdir(parents=True)
+        (cli / "index.ts").write_text(
+            max(blocks(CLIENT_PAGE, "ts"), key=len).replace("4021", str(PORT)))
+        sh("npm init -y && npm pkg set type=module", cli)
+        for line in install_lines(CLIENT_PAGE, "npm install"):
+            if sh(line, cli).returncode:
+                raise RuntimeError(f"client install failed: {line}")
+        sh("npm install -D tsx", cli)
+        (cli / ".env").write_text(
+            f"EVM_PRIVATE_KEY={os.environ['EVM_PRIVATE_KEY']}\n"
+            f"SVM_PRIVATE_KEY={os.environ['SVM_PRIVATE_KEY']}\n"
+            f"RESOURCE_SERVER_URL=http://localhost:{PORT}\n"
+            f"ENDPOINT_PATH=/weather\n")
+
+        env = {**os.environ,
+               "FACILITATOR_URL": "https://facilitator.payai.network",
+               "PORT": str(PORT)}
+        print(f"→ starting the authenticated server on :{PORT}")
+        proc = subprocess.Popen(
+            f"{vpy} -m uvicorn main:app --host 127.0.0.1 --port {PORT}",
+            cwd=srv, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=env, preexec_fn=os.setsid)
+
+        url = f"http://localhost:{PORT}/weather"
+        for _ in range(60):
+            time.sleep(1)
+            if proc.poll() is not None:
+                raise RuntimeError("server exited early:\n" + (proc.stdout.read() or "")[-1500:])
+            try:
+                urllib.request.urlopen(url, timeout=3)
+            except urllib.error.HTTPError as e:
+                if e.code == 402:
+                    print("   server is up and returning 402 (auth provider active)")
+                    break
+            except Exception:
+                continue
+        else:
+            raise RuntimeError("server never returned a 402")
+
+        print("→ paying it with the documented Fetch client")
+        r = sh("npx tsx index.ts", cli)
+        out = (r.stdout or "") + (r.stderr or "")
+        print("\n".join("   " + l for l in out.strip().splitlines()[-20:]))
+
+        if "insufficient_balance" in out:
+            raise RuntimeError("payer wallet is not funded — top up the CI testnet wallets")
+        if "payment_required" in out or "status: 402" in out:
+            raise RuntimeError("payment did not settle; the merchant may have failed to authenticate")
+        if "status: 200" not in out:
+            raise RuntimeError("client never saw a 200")
+
+        print("\n✓ authenticated settlement: the documented FastAPI server signed a "
+              "PayAI JWT, the facilitator accepted it, and the payment settled.")
+        return 0
+    except Exception as e:
+        print(f"\n✗ auth check failed: {e}")
+        return 1
+    finally:
+        if proc and proc.poll() is None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except Exception:
+                proc.terminate()
+        shutil.rmtree(work, ignore_errors=True)
+
+
+sys.exit(main())

--- a/x402/facilitators/authentication.mdx
+++ b/x402/facilitators/authentication.mdx
@@ -85,7 +85,7 @@ Include the JWT as a Bearer token on all facilitator requests:
 Authorization: Bearer <jwt>
 ```
 
-This header is required on all authenticated facilitator endpoints: `POST /verify`, `POST /settle`, and `GET /supported`.
+Send this header on `POST /verify` and `POST /settle`. `GET /supported` is currently readable without a token — it returns the same catalogue either way — so authenticating it is harmless but not required.
 
 ---
 
@@ -490,13 +490,13 @@ The following examples implement the full authentication flow with **no PayAI-sp
 
 ## Facilitator endpoints
 
-All endpoints are at `https://facilitator.payai.network` and require the `Authorization: Bearer <jwt>` header when authenticated.
+All endpoints are at `https://facilitator.payai.network`. Note that `/verify` validates the request body before the token, so a malformed request returns `400` rather than `401` even when the token is missing or bad.
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/verify` | POST | Verify a payment payload against payment requirements |
-| `/settle` | POST | Settle a verified payment on-chain |
-| `/supported` | GET | List supported networks, tokens, and schemes |
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/verify` | POST | required beyond the free tier | Verify a payment payload against payment requirements |
+| `/settle` | POST | required beyond the free tier | Settle a verified payment on-chain |
+| `/supported` | GET | not required | List supported networks, tokens, and schemes |
 
 ### Request body (`/verify` and `/settle`)
 

--- a/x402/servers/go/gin.mdx
+++ b/x402/servers/go/gin.mdx
@@ -194,6 +194,147 @@ go run .
 
 You can test payments against your server locally by following the [fetch example](/x402/clients/typescript/fetch) or the [axios example](/x402/clients/typescript/axios), or by using the Go client examples in the [x402 repository](https://github.com/x402-foundation/x402/tree/main/examples/go/clients).
 
+## Going to production
+
+This setup works on the **free tier** out of the box — no API keys required.
+
+Beyond the free tier the facilitator authenticates merchants with short-lived
+Ed25519 JWTs. Create a merchant account at
+[merchant.payai.network](https://merchant.payai.network), then add your keys to
+your `.env`:
+
+```env
+PAYAI_API_KEY_ID=your-key-id
+PAYAI_API_KEY_SECRET=payai_sk_your-api-key-secret
+```
+
+There is no PayAI module for Go — the x402 SDK takes an `AuthProvider`, so
+signing the token is all you need. Put this in `payaiauth/provider.go`:
+
+```go
+// Package payaiauth signs short-lived EdDSA JWTs for the PayAI facilitator.
+package payaiauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	x402http "github.com/x402-foundation/x402/go/http"
+)
+
+// Provider implements x402http.AuthProvider.
+type Provider struct {
+	keyID string
+	key   ed25519.PrivateKey
+	ttl   time.Duration
+
+	mu      sync.Mutex
+	token   string
+	renewAt time.Time
+}
+
+// New builds a Provider from a PayAI API key ID and secret. The secret may
+// carry the payai_sk_ prefix shown in the merchant dashboard.
+func New(apiKeyID, apiKeySecret string) (*Provider, error) {
+	secret := strings.TrimPrefix(strings.TrimSpace(apiKeySecret), "payai_sk_")
+	der, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		if der, err = base64.URLEncoding.DecodeString(secret); err != nil {
+			return nil, fmt.Errorf("decode API key secret: %w", err)
+		}
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKCS#8 key: %w", err)
+	}
+	key, ok := parsed.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("API key secret is not an Ed25519 key")
+	}
+	return &Provider{keyID: apiKeyID, key: key, ttl: 120 * time.Second}, nil
+}
+
+func b64(raw []byte) string {
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func uuidV4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+func (p *Provider) jwt() (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.token != "" && time.Now().Before(p.renewAt) {
+		return p.token, nil
+	}
+	now := time.Now()
+	jti, err := uuidV4()
+	if err != nil {
+		return "", err
+	}
+	header, _ := json.Marshal(map[string]string{"alg": "EdDSA", "typ": "JWT", "kid": p.keyID})
+	payload, _ := json.Marshal(map[string]any{
+		"sub": p.keyID, "iss": "payai-merchant",
+		"iat": now.Unix(), "exp": now.Add(p.ttl).Unix(), "jti": jti,
+	})
+	msg := b64(header) + "." + b64(payload)
+	p.token = msg + "." + b64(ed25519.Sign(p.key, []byte(msg)))
+	// refresh early so an in-flight request never carries a token that expires
+	// mid-lifetime
+	p.renewAt = now.Add(p.ttl - 30*time.Second)
+	return p.token, nil
+}
+
+// GetAuthHeaders satisfies x402http.AuthProvider.
+func (p *Provider) GetAuthHeaders(ctx context.Context) (x402http.AuthHeaders, error) {
+	t, err := p.jwt()
+	if err != nil {
+		return x402http.AuthHeaders{}, err
+	}
+	h := map[string]string{"Authorization": "Bearer " + t}
+	return x402http.AuthHeaders{Verify: h, Settle: h, Supported: h, Bazaar: h}, nil
+}
+```
+
+Then pass it to the facilitator client:
+
+```go
+authProvider, err := payaiauth.New(
+	os.Getenv("PAYAI_API_KEY_ID"),
+	os.Getenv("PAYAI_API_KEY_SECRET"),
+)
+if err != nil {
+	fmt.Printf("❌ PayAI auth: %v\n", err)
+	os.Exit(1)
+}
+
+facilitatorClient := x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+	URL:          facilitatorURL,
+	AuthProvider: authProvider,
+})
+```
+
+The provider caches each token and re-signs 30 seconds before expiry, so a
+long-running server signs roughly once every two minutes rather than on every
+request. See [Facilitator Pricing](/x402/facilitators/pricing) for tier details
+and [Facilitator Authentication](/x402/facilitators/authentication) for the
+protocol reference.
+
 ## x402 reference
 
 For a deeper dive into message shapes, headers, verification and settlement responses, see the [x402 Reference](/x402/reference).

--- a/x402/servers/python/fastapi.mdx
+++ b/x402/servers/python/fastapi.mdx
@@ -159,6 +159,103 @@ You can test payments against your server locally by following the [httpx exampl
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 
+## Going to production
+
+This setup works on the **free tier** out of the box — no API keys required.
+
+Beyond the free tier the facilitator authenticates merchants with short-lived
+Ed25519 JWTs. Create a merchant account at
+[merchant.payai.network](https://merchant.payai.network), then add your keys to
+your `.env`:
+
+```env
+PAYAI_API_KEY_ID=your-key-id
+PAYAI_API_KEY_SECRET=payai_sk_your-api-key-secret
+```
+
+There is no PayAI package for Python — the x402 SDK takes an `auth_provider`, so
+signing the token is all you need. Install `cryptography` and drop this file
+beside your `main.py`:
+
+```bash
+pip install cryptography
+```
+
+```python
+import base64, json, time, uuid
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+from x402.http.facilitator_client_base import AuthHeaders
+
+
+class PayAIAuthProvider:
+    """Signs short-lived EdDSA JWTs for the PayAI facilitator.
+
+    Implements the x402 AuthProvider protocol, so the facilitator client
+    attaches the token to every request without further wiring.
+    """
+
+    def __init__(self, api_key_id: str, api_key_secret: str, ttl: int = 120):
+        self._kid = api_key_id
+        secret = api_key_secret.strip()
+        if secret.startswith("payai_sk_"):
+            secret = secret[len("payai_sk_"):]
+        self._key = load_der_private_key(base64.b64decode(secret), password=None)
+        self._ttl = ttl
+        self._token: str | None = None
+        self._renew_at = 0.0
+
+    @staticmethod
+    def _b64(raw: bytes) -> str:
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    def _mint(self) -> str:
+        now = int(time.time())
+        header = self._b64(json.dumps(
+            {"alg": "EdDSA", "typ": "JWT", "kid": self._kid},
+            separators=(",", ":")).encode())
+        payload = self._b64(json.dumps(
+            {"sub": self._kid, "iss": "payai-merchant", "iat": now,
+             "exp": now + self._ttl, "jti": str(uuid.uuid4())},
+            separators=(",", ":")).encode())
+        message = f"{header}.{payload}"
+        self._token = f"{message}.{self._b64(self._key.sign(message.encode()))}"
+        # refresh a little early so an in-flight request never carries a token
+        # that expires mid-lifetime
+        self._renew_at = now + self._ttl - 30
+        return self._token
+
+    def _jwt(self) -> str:
+        if self._token and time.time() < self._renew_at:
+            return self._token
+        return self._mint()
+
+    def get_auth_headers(self) -> AuthHeaders:
+        h = {"Authorization": f"Bearer {self._jwt()}"}
+        return AuthHeaders(verify=h, settle=h, supported=h, bazaar=h)
+```
+
+Then pass it to the facilitator client:
+
+```python
+from payai_auth import PayAIAuthProvider
+
+facilitator = HTTPFacilitatorClient(
+    FacilitatorConfig(
+        url=FACILITATOR_URL,
+        auth_provider=PayAIAuthProvider(
+            os.environ["PAYAI_API_KEY_ID"],
+            os.environ["PAYAI_API_KEY_SECRET"],
+        ),
+    )
+)
+```
+
+The provider caches each token and re-signs 30 seconds before expiry, so a
+long-running server signs roughly once every two minutes rather than on every
+request. See [Facilitator Pricing](/x402/facilitators/pricing) for tier details
+and [Facilitator Authentication](/x402/facilitators/authentication) for the
+protocol reference.
+
 ## x402 reference
 
 For a deeper dive into message shapes, headers, verification and settlement responses, see the [x402 Reference](/x402/reference).

--- a/x402/servers/python/flask.mdx
+++ b/x402/servers/python/flask.mdx
@@ -142,6 +142,103 @@ You can test payments against your server locally by following the [httpx exampl
 
 Just set your environment variables to match your local server, install the dependencies, and run the examples.
 
+## Going to production
+
+This setup works on the **free tier** out of the box — no API keys required.
+
+Beyond the free tier the facilitator authenticates merchants with short-lived
+Ed25519 JWTs. Create a merchant account at
+[merchant.payai.network](https://merchant.payai.network), then add your keys to
+your `.env`:
+
+```env
+PAYAI_API_KEY_ID=your-key-id
+PAYAI_API_KEY_SECRET=payai_sk_your-api-key-secret
+```
+
+There is no PayAI package for Python — the x402 SDK takes an `auth_provider`, so
+signing the token is all you need. Install `cryptography` and drop this file
+beside your `main.py`:
+
+```bash
+pip install cryptography
+```
+
+```python
+import base64, json, time, uuid
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+from x402.http.facilitator_client_base import AuthHeaders
+
+
+class PayAIAuthProvider:
+    """Signs short-lived EdDSA JWTs for the PayAI facilitator.
+
+    Implements the x402 AuthProvider protocol, so the facilitator client
+    attaches the token to every request without further wiring.
+    """
+
+    def __init__(self, api_key_id: str, api_key_secret: str, ttl: int = 120):
+        self._kid = api_key_id
+        secret = api_key_secret.strip()
+        if secret.startswith("payai_sk_"):
+            secret = secret[len("payai_sk_"):]
+        self._key = load_der_private_key(base64.b64decode(secret), password=None)
+        self._ttl = ttl
+        self._token: str | None = None
+        self._renew_at = 0.0
+
+    @staticmethod
+    def _b64(raw: bytes) -> str:
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    def _mint(self) -> str:
+        now = int(time.time())
+        header = self._b64(json.dumps(
+            {"alg": "EdDSA", "typ": "JWT", "kid": self._kid},
+            separators=(",", ":")).encode())
+        payload = self._b64(json.dumps(
+            {"sub": self._kid, "iss": "payai-merchant", "iat": now,
+             "exp": now + self._ttl, "jti": str(uuid.uuid4())},
+            separators=(",", ":")).encode())
+        message = f"{header}.{payload}"
+        self._token = f"{message}.{self._b64(self._key.sign(message.encode()))}"
+        # refresh a little early so an in-flight request never carries a token
+        # that expires mid-lifetime
+        self._renew_at = now + self._ttl - 30
+        return self._token
+
+    def _jwt(self) -> str:
+        if self._token and time.time() < self._renew_at:
+            return self._token
+        return self._mint()
+
+    def get_auth_headers(self) -> AuthHeaders:
+        h = {"Authorization": f"Bearer {self._jwt()}"}
+        return AuthHeaders(verify=h, settle=h, supported=h, bazaar=h)
+```
+
+Then pass it to the facilitator client:
+
+```python
+from payai_auth import PayAIAuthProvider
+
+facilitator = HTTPFacilitatorClient(
+    FacilitatorConfig(
+        url=FACILITATOR_URL,
+        auth_provider=PayAIAuthProvider(
+            os.environ["PAYAI_API_KEY_ID"],
+            os.environ["PAYAI_API_KEY_SECRET"],
+        ),
+    )
+)
+```
+
+The provider caches each token and re-signs 30 seconds before expiry, so a
+long-running server signs roughly once every two minutes rather than on every
+request. See [Facilitator Pricing](/x402/facilitators/pricing) for tier details
+and [Facilitator Authentication](/x402/facilitators/authentication) for the
+protocol reference.
+
 ## x402 reference
 
 For a deeper dive into message shapes, headers, verification and settlement responses, see the [x402 Reference](/x402/reference).


### PR DESCRIPTION
None of the Python or Go pages mentioned `PAYAI_API_KEY` or linked to the auth reference, so a Python or Go merchant had **no documented path past the free tier**. Adds a "Going to production" section to fastapi, flask and gin.

## Three pages, not six

Clients never talk to a facilitator. `httpx`, `requests` and `go/http` contain **zero** facilitator references — adding auth to them would be wrong. Only servers authenticate.

## Inline, not new packages

We just deprecated five packages for going unmaintained. Publishing a PyPI package and a Go module to hold ~40 lines would recreate exactly that surface. The code implements a **stable spec** (EdDSA JWT), not a moving API, so it doesn't drift the way an SDK wrapper does — and inline code is visible to agents reading `llms-full.txt`, where a package reference isn't.

## It implements an interface, not a header hack

Both SDKs already have first-class hooks — I checked before writing anything:

```python
# x402.http
FacilitatorConfig(url=..., auth_provider=...)     # AuthProvider protocol
class AuthProvider(Protocol):
    def get_auth_headers(self) -> AuthHeaders: ...
```
```go
// x402http
FacilitatorConfig{URL: ..., AuthProvider: ...}    // AuthProvider interface
GetAuthHeaders(ctx) (AuthHeaders, error)
```

Both providers cache the token and re-sign 30s before expiry, so a long-running server signs about once every two minutes rather than per request.

## Docs bug fixed

The auth page claimed the `Authorization` header is **required on `GET /supported`**. It isn't — the live facilitator returns `200` with no token *and* with a bogus one. The endpoint table now carries an Auth column, and the page notes that `/verify` validates the body before the token, so a malformed request returns `400` rather than `401` even with no token at all.

## How it's verified

The auth provider blocks are now **compiled as part of their pages**, so they can't ship broken:

```
fastapi  ✓ 2 file(s) parse; all 6 third-party imports resolve against x402==2.18.0
flask    ✓ 2 file(s) parse; all 4 third-party imports resolve against x402==2.18.0
gin      ✓ builds clean against github.com/x402-foundation/x402/go
```

Beyond that, `scripts/check_auth_live.py` boots the documented FastAPI server **with the provider wired in** and pays it with the documented Fetch client against the live facilitator.

**That shape is deliberate, and I arrived at it by trying the obvious thing first.** Probing `/verify` cannot prove a token was accepted — the facilitator validates the body before the token, so absent, malformed, and unsigned-but-well-formed tokens all return an identical `400`:

```
auth=none                            -> 400 invalid_payload
auth=malformed                       -> 400 invalid_payload
auth=structurally-valid-but-unsigned -> 400 invalid_payload
```

And unauthenticated requests succeed anyway on the free tier, so "did not 401" proves nothing either. **A settled payment through a server configured with the provider is the only signal that means the token was actually accepted.**

## Local verification before pushing

| check | result |
|---|---|
| Python provider signs + verifies against its key | ✓ |
| Python provider caches (token reused) | ✓ |
| SDK accepts it as `auth_provider` | ✓ |
| works with and without the `payai_sk_` prefix | ✓ |
| Go provider signs + verifies, satisfies the interface at compile time | ✓ |
| Go provider caches | ✓ |
| the wiring substitution matches the current FastAPI page | ✓ |
| skip path exit 0 / `--require` exit 1 | ✓ |
| deltas, links, sync all clean; no sync drift from the new blocks | ✓ |

One thing caught along the way: the Go `AuthHeaders` field is `Bazaar`, not `Discovery`. I initially read `Discovery` from a **stale module in the local cache** (`20260414`) while the version the docs actually resolve (`20260529`) had renamed it. It failed to compile, which is how I found it — worth knowing when reading SDK internals from `GOMODCACHE`.

The `auth` CI job runs `--require`, so it's a hard failure rather than a silent skip.