### PR TITLE
fix: the Python examples could not actually run

### DIFF
--- a/scripts/check-examples.py
+++ b/scripts/check-examples.py
@@ -176,23 +176,45 @@ def check_python(cfg, text, d):
             return False, f"{rel} does not parse: line {e.lineno}: {e.msg}"
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
-                imported |= {a.name.split(".")[0] for a in node.names}
+                imported |= {a.name for a in node.names}
             elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-                imported.add(node.module.split(".")[0])
-    third_party = sorted(imported - PY_STDLIB_OK - local)
+                imported.add(node.module)
+    modules = sorted(m for m in imported
+                     if m.split(".")[0] not in PY_STDLIB_OK
+                     and m.split(".")[0] not in local)
 
-    probe = ("import importlib.util,sys;"
-             "missing=[m for m in sys.argv[1:] if importlib.util.find_spec(m) is None];"
-             "print(','.join(missing))")
-    r = run(f"{py} -c {json.dumps(probe)} {' '.join(third_party)}", d)
-    missing = [m for m in (r.stdout or "").strip().split(",") if m]
-    if missing:
-        return False, (f"code imports {', '.join(missing)} but the page's install "
-                       f"line does not provide it")
+    # Import each module for real rather than find_spec-ing the top-level name.
+    # find_spec("x402") succeeds even when the page forgot an optional extra, and
+    # the failure only surfaces when x402.mechanisms.evm executes its __init__ and
+    # raises "requires ethereum packages. Install with: pip install x402[evm]".
+    #
+    # The probe goes in a file, not `python -c`: passing a multi-line program
+    # through the shell delivers literal backslash-n, the probe dies on a syntax
+    # error, and empty stdout reads as "nothing failed" — a check that silently
+    # passes everything.
+    probe = d / "_probe_imports.py"
+    probe.write_text(
+        "import importlib, sys\n"
+        "bad = []\n"
+        "for m in sys.argv[1:]:\n"
+        "    try:\n"
+        "        importlib.import_module(m)\n"
+        "    except Exception as e:\n"
+        "        bad.append(f'{m}: {type(e).__name__}: {e}')\n"
+        "print('\\n'.join(bad))\n")
+    r = run(f"{py} {probe} {' '.join(modules)}", d)
+    if r.returncode != 0:
+        return False, ("import probe itself failed — treat as a checker bug, not a "
+                       f"passing page:\n{(r.stderr or r.stdout)[-400:]}")
+    failures = [l for l in (r.stdout or "").strip().splitlines() if l.strip()]
+    if failures:
+        return False, ("the page's install line does not satisfy its own imports:\n    "
+                       + "\n    ".join(failures[:6]))
+
     show = run(f"{py} -m pip show x402", d).stdout
     v = next((l.split(": ", 1)[1].strip() for l in show.splitlines()
               if l.startswith("Version:")), None)
-    return True, (f"{len(cfg['files'])} file(s) parse; all {len(third_party)} third-party imports resolve"
+    return True, (f"{len(cfg['files'])} file(s) parse; all {len(modules)} imported module(s) load"
                   + (f" against x402=={v}" if v else "") + f" [py{ver}]")
 
 

--- a/x402/clients/python/httpx.mdx
+++ b/x402/clients/python/httpx.mdx
@@ -9,8 +9,16 @@ Make x402 payments with an httpx client in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install 'x402[evm,svm]' httpx eth-account python-dotenv
+pip install 'x402[evm,svm]' 'solana<0.40' httpx eth-account python-dotenv
 ```
+
+<Note>
+  `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
+  upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
+  which `x402`'s SVM signer still imports — so an unpinned install resolves to a
+  version the SDK cannot use. Drop the pin once upstream constrains it.
+</Note>
+
 
 <Note>The `[evm,svm]` extras pull in the EVM and SVM payment mechanisms used below. Without them, the `x402.mechanisms.evm` / `x402.mechanisms.svm` imports fail. Install only the extra you need (e.g. `'x402[svm]'`) if you're paying on a single network. The quotes keep shells like zsh from expanding the brackets.</Note>
 

--- a/x402/clients/python/requests.mdx
+++ b/x402/clients/python/requests.mdx
@@ -9,8 +9,16 @@ Make x402 payments with a requests client in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install 'x402[evm,svm]' requests eth-account python-dotenv
+pip install 'x402[evm,svm]' 'solana<0.40' requests eth-account python-dotenv
 ```
+
+<Note>
+  `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
+  upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
+  which `x402`'s SVM signer still imports — so an unpinned install resolves to a
+  version the SDK cannot use. Drop the pin once upstream constrains it.
+</Note>
+
 
 <Note>The `[evm,svm]` extras pull in the EVM and SVM payment mechanisms used below. Without them, the `x402.mechanisms.evm` / `x402.mechanisms.svm` imports fail. Install only the extra you need (e.g. `'x402[svm]'`) if you're paying on a single network. The quotes keep shells like zsh from expanding the brackets.</Note>
 

--- a/x402/servers/python/fastapi.mdx
+++ b/x402/servers/python/fastapi.mdx
@@ -9,8 +9,16 @@ Start accepting x402 payments in your FastAPI server in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install x402 fastapi uvicorn python-dotenv pydantic
+pip install 'x402[evm,svm]' 'solana<0.40' fastapi uvicorn python-dotenv pydantic
 ```
+
+<Note>
+  `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
+  upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
+  which `x402`'s SVM signer still imports — so an unpinned install resolves to a
+  version the SDK cannot use. Drop the pin once upstream constrains it.
+</Note>
+
 
 ### Step 2: Set your environment variables
 

--- a/x402/servers/python/flask.mdx
+++ b/x402/servers/python/flask.mdx
@@ -9,8 +9,16 @@ Start accepting x402 payments in your Flask server in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install x402 flask python-dotenv
+pip install 'x402[evm,svm]' 'solana<0.40' flask python-dotenv
 ```
+
+<Note>
+  `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
+  upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
+  which `x402`'s SVM signer still imports — so an unpinned install resolves to a
+  version the SDK cannot use. Drop the pin once upstream constrains it.
+</Note>
+
 
 ### Step 2: Set your environment variables
 


### PR DESCRIPTION
The auth gate on #57 failed and **the failure was real**. Pulling that thread turned up three separate bugs.

## 1. The Python server pages installed the wrong thing

| page | installs | imports | |
|---|---|---|---|
| fastapi | `x402` | `x402.mechanisms.evm.exact` | ✗ |
| flask | `x402` | `x402.mechanisms.evm.exact` | ✗ |
| httpx | `x402[evm,svm]` | | ✓ |
| requests | `x402[evm,svm]` | | ✓ |

Following fastapi.mdx or flask.mdx gave you an `ImportError` on startup:

```
ImportError: EVM mechanism requires ethereum packages. Install with: pip install x402[evm]
```

The client pages had it right; the server pages didn't.

## 2. `x402[svm]` is broken on PyPI right now

This one affected **every** Python page, extras or not. `x402[svm]` requires `solana>=0.36.0` with **no upper bound**, and `solana` 0.40 removed two APIs that x402's own SVM signer still imports:

```
solana.rpc.api.Client       -> ModuleNotFoundError: No module named 'solana.rpc.api'
solana.rpc.types.TxOpts     -> AttributeError: module has no attribute 'TxOpts'
```

So `pip install 'x402[svm]'` installs `solana==0.40.1` — a version the SDK cannot use. Solana support was broken for anyone following these pages.

Pinned `solana<0.40`, which resolves 0.39.0 and imports cleanly, with a note on each page saying to drop the pin once upstream constrains it. **Worth reporting upstream** — the fix belongs in x402's `pyproject.toml`, not in our docs.

## 3. The compile check couldn't catch either — or anything

Two defects, and the second is the serious one.

It only `find_spec`'d **top-level** module names. `find_spec("x402")` succeeds even when an extra is missing; the failure only surfaces when the submodule executes its `__init__`.

Worse, the fix I first wrote for that was itself broken. The probe was passed to `python -c` through the shell as a `json.dumps` string, so bash delivered **literal backslash-n**. The probe died on a syntax error, produced empty stdout, and empty was read as "nothing failed" — a check that silently passed everything.

The probe now runs from a file, imports every dotted module the page actually uses, and **a non-zero probe exit is itself a failure rather than a pass**.

I caught this only because the regression test I wrote to prove the fix worked came back green when it should have been red.

## Verification

Every fix reverted in turn, and the check watched to fail, then pass:

```
# with the old install line
✗ the page's install line does not satisfy its own imports:
    x402.mechanisms.evm.exact: ImportError: EVM mechanism requires ethereum packages...
    x402.mechanisms.svm.exact: ImportError: SVM mechanism requires solana packages...

# after both fixes
✓ 2 file(s) parse; all 13 imported module(s) load against x402==2.18.0
```

All 11 examples check out; deltas, links and sync all clean.

## Note

#57 is already merged, so `main` currently carries auth sections on pages whose install lines don't work. This restores them.