### PR TITLE
fix: the Python servers 500 on the first paid request (and make the gate that found it blockable)

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -58,11 +58,10 @@ jobs:
   auth:
     name: Authenticated settlement (PayAI JWT)
     runs-on: ubuntu-latest
-    # Not yet trusted as a merge gate. It failed on #57 and #58 for reasons I
-    # could not reproduce locally, and a check that is red for unclear reasons
-    # trains people to ignore it. It runs and reports; flip this off once a few
-    # runs have been green and the failure mode is understood.
-    continue-on-error: true
+    # This blocks. It failed on #57 and #58 and I suspected the gate; the gate
+    # was right. Once it reported what it actually saw, the answer was
+    # ModuleNotFoundError: httpx on the first request to a paid route — the
+    # install lines omitted it. Both server pages were genuinely broken.
     timeout-minutes: 25
     if: github.event.pull_request.head.repo.full_name == github.repository
     environment: docs-live-payment

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -3,8 +3,19 @@ name: Validate examples
 on:
   pull_request:
     paths:
-      - "x402/servers/typescript/**"
-      - "x402/clients/typescript/**"
+      # All languages, not just typescript. check_deltas.py covers 11 pages
+      # across ts/python/go, and the auth gate is built on the FastAPI page —
+      # but this filter still said "typescript", so a PR touching only Python
+      # or Go pages skipped every job here. #57 and #58 ran these gates only
+      # because they happened to touch scripts/ as well.
+      #
+      # That gap was worst exactly where it was least visible: the Python and
+      # Go delta is the FACILITATOR_URL line in the .env block, and upstream
+      # falls back to x402.org/facilitator when it is unset — so losing it
+      # breaks nothing loudly. check_deltas.py exists to catch that, and it
+      # was not running on those pages.
+      - "x402/servers/**"
+      - "x402/clients/**"
       - "patches/**"
       - "scripts/**"
       - ".github/workflows/validate-examples.yml"

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -47,6 +47,11 @@ jobs:
   auth:
     name: Authenticated settlement (PayAI JWT)
     runs-on: ubuntu-latest
+    # Not yet trusted as a merge gate. It failed on #57 and #58 for reasons I
+    # could not reproduce locally, and a check that is red for unclear reasons
+    # trains people to ignore it. It runs and reports; flip this off once a few
+    # runs have been green and the failure mode is understood.
+    continue-on-error: true
     timeout-minutes: 25
     if: github.event.pull_request.head.repo.full_name == github.repository
     environment: docs-live-payment

--- a/scripts/check_auth_live.py
+++ b/scripts/check_auth_live.py
@@ -86,6 +86,18 @@ def wire_auth(main_src):
     return new
 
 
+def _drain(proc):
+    """Best-effort read of the server's output so a failure carries evidence."""
+    import fcntl, os as _os
+    try:
+        fd = proc.stdout.fileno()
+        fcntl.fcntl(fd, fcntl.F_SETFL,
+                    fcntl.fcntl(fd, fcntl.F_GETFL) | _os.O_NONBLOCK)
+        return proc.stdout.read() or "(no output)"
+    except Exception as e:
+        return f"(could not read server output: {e})"
+
+
 def main():
     require = "--require" in sys.argv
     missing = [k for k in NEEDED if not os.environ.get(k)]
@@ -138,20 +150,38 @@ def main():
             text=True, env=env, preexec_fn=os.setsid)
 
         url = f"http://localhost:{PORT}/weather"
+        seen = []          # what the server actually said, so a failure is diagnosable
         for _ in range(60):
             time.sleep(1)
             if proc.poll() is not None:
                 raise RuntimeError("server exited early:\n" + (proc.stdout.read() or "")[-1500:])
             try:
-                urllib.request.urlopen(url, timeout=3)
+                r = urllib.request.urlopen(url, timeout=5)
+                seen.append(f"{r.status} (unprotected?)")
             except urllib.error.HTTPError as e:
                 if e.code == 402:
                     print("   server is up and returning 402 (auth provider active)")
                     break
-            except Exception:
-                continue
+                body = ""
+                try:
+                    body = e.read().decode()[:200]
+                except Exception:
+                    pass
+                seen.append(f"{e.code} {body}".strip())
+            except Exception as e:
+                seen.append(type(e).__name__)
         else:
-            raise RuntimeError("server never returned a 402")
+            tally = {}
+            for s in seen:
+                tally[s] = tally.get(s, 0) + 1
+            summary = "; ".join(f"{n}x {s}" for s, n in
+                                sorted(tally.items(), key=lambda kv: -kv[1])[:4])
+            raise RuntimeError(
+                "server never returned a 402.\n"
+                f"    what it did return: {summary or '(nothing)'}\n"
+                "    server output:\n"
+                + "\n".join("      " + l for l in
+                             _drain(proc).splitlines()[-25:]))
 
         print("→ paying it with the documented Fetch client")
         r = sh("npx tsx index.ts", cli)

--- a/x402/servers/python/fastapi.mdx
+++ b/x402/servers/python/fastapi.mdx
@@ -9,7 +9,7 @@ Start accepting x402 payments in your FastAPI server in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install 'x402[evm,svm]' 'solana<0.40' fastapi uvicorn python-dotenv pydantic
+pip install 'x402[fastapi,httpx,evm,svm]' 'solana<0.40' uvicorn python-dotenv pydantic
 ```
 
 <Note>

--- a/x402/servers/python/flask.mdx
+++ b/x402/servers/python/flask.mdx
@@ -9,7 +9,7 @@ Start accepting x402 payments in your Flask server in 2 minutes.
 ### Step 1: Install dependencies
 
 ```bash
-pip install 'x402[evm,svm]' 'solana<0.40' flask python-dotenv
+pip install 'x402[flask,httpx,evm,svm]' 'solana<0.40' python-dotenv
 ```
 
 <Note>


### PR DESCRIPTION
## Answering the question directly: no, that failure was not expected

And it is **not a regression from #58** — that PR's fixes are sound and its other four checks passed. The auth gate itself is unproven.

## Why I could not tell you more than that

The gate threw the evidence away. It polled for a 402 and, on timeout, reported only:

```
✗ auth check failed: server never returned a 402
```

without saying what the server *did* return or what it logged. A 500, a 404, a 200, and a connection refusal all produced that identical message.

So I went looking locally, and could not reproduce it. I did see a 500 once, then the same wired server returned **402 on 8 of 8 consecutive requests**. The unwired example returns 402 too. I have a hypothesis about a cold-start facilitator call, but I could not confirm it, and I would rather say that plainly than ship a guess as a fix.

## What this changes

**The gate now carries evidence.** It records every status it saw, tallies them, and prints the server's own output on failure:

```
✗ server never returned a 402.
    what it did return: 47x 500 Internal Server Error; 13x URLError
    server output:
      INFO:     Started server process
      ...
```

The next failure should be readable straight from the CI log.

**`continue-on-error: true` on the auth job.** It runs and reports but does not block merges, until a few runs have been green and the failure mode is understood.

That is deliberate. A check that is red for reasons nobody can explain trains people to scroll past red checks — which costs more than the check is worth. The live-payment gate stays a hard gate; it has been reliably green and has proven on-chain settlement.

## To be clear about what is and isn't verified

| | |
|---|---|
| Python auth provider signs a valid EdDSA JWT | verified |
| Go auth provider signs a valid EdDSA JWT | verified |
| both satisfy their SDK's AuthProvider interface | verified |
| both compile as part of their pages | verified in CI |
| the facilitator **accepts** these tokens end to end | **not yet proven** |

That last row is the whole point of the gate, and it is still open.