### PR TITLE
docs: link the solana pin note to the upstream fix

### DIFF
--- a/x402/clients/python/httpx.mdx
+++ b/x402/clients/python/httpx.mdx
@@ -16,7 +16,9 @@ pip install 'x402[evm,svm]' 'solana<0.40' httpx eth-account python-dotenv
   `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
   upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
   which `x402`'s SVM signer still imports — so an unpinned install resolves to a
-  version the SDK cannot use. Drop the pin once upstream constrains it.
+  version the SDK cannot use. A fix is proposed upstream in
+  [x402-foundation/x402#3071](https://github.com/x402-foundation/x402/pull/3071) —
+  drop the pin once it ships in an `x402` release.
 </Note>
 
 

--- a/x402/clients/python/requests.mdx
+++ b/x402/clients/python/requests.mdx
@@ -16,7 +16,9 @@ pip install 'x402[evm,svm]' 'solana<0.40' requests eth-account python-dotenv
   `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
   upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
   which `x402`'s SVM signer still imports — so an unpinned install resolves to a
-  version the SDK cannot use. Drop the pin once upstream constrains it.
+  version the SDK cannot use. A fix is proposed upstream in
+  [x402-foundation/x402#3071](https://github.com/x402-foundation/x402/pull/3071) —
+  drop the pin once it ships in an `x402` release.
 </Note>
 
 

--- a/x402/servers/python/fastapi.mdx
+++ b/x402/servers/python/fastapi.mdx
@@ -16,7 +16,9 @@ pip install 'x402[evm,svm]' 'solana<0.40' fastapi uvicorn python-dotenv pydantic
   `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
   upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
   which `x402`'s SVM signer still imports — so an unpinned install resolves to a
-  version the SDK cannot use. Drop the pin once upstream constrains it.
+  version the SDK cannot use. A fix is proposed upstream in
+  [x402-foundation/x402#3071](https://github.com/x402-foundation/x402/pull/3071) —
+  drop the pin once it ships in an `x402` release.
 </Note>
 
 

--- a/x402/servers/python/flask.mdx
+++ b/x402/servers/python/flask.mdx
@@ -16,7 +16,9 @@ pip install 'x402[evm,svm]' 'solana<0.40' flask python-dotenv
   `solana<0.40` is a temporary pin. `x402[svm]` requires `solana>=0.36.0` with no
   upper bound, but `solana` 0.40 removed `solana.rpc.api` and `rpc.types.TxOpts`,
   which `x402`'s SVM signer still imports — so an unpinned install resolves to a
-  version the SDK cannot use. Drop the pin once upstream constrains it.
+  version the SDK cannot use. A fix is proposed upstream in
+  [x402-foundation/x402#3071](https://github.com/x402-foundation/x402/pull/3071) —
+  drop the pin once it ships in an `x402` release.
 </Note>
 
 


### PR DESCRIPTION
The four Python pages pin `solana<0.40` to work around `x402[svm]` declaring an unbounded `solana>=0.36.0`. The note told readers to drop the pin "once upstream constrains it" without saying where to watch for that.

Now it points at [x402-foundation/x402#3071](https://github.com/x402-foundation/x402/pull/3071), and says a merge alone isn't the signal — the constraint has to ship in an `x402` PyPI release before the pin can go.

Prose only; no install lines or code blocks changed. Pages: `fastapi`, `flask`, `httpx`, `requests`.

Verified locally: `check_deltas` 11/11, `check-links` clean (167 links), `sync_upstream --check` reports no drift on all four — confirming prose edits don't need a patch regen. The linked URL returns HTTP 200.